### PR TITLE
Temporarily install django-nested-admin from github

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,5 @@ pyjwt
 django-enumfields==0.7.4
 pytz==2015.7
 jsonfield==1.0.3
-django-nested-admin==2.1.8
+# TODO get this from PyPI once available
+git+https://github.com/theatlantic/django-nested-admin.git@v2.1.11#egg=django-nested-admin


### PR DESCRIPTION
The newest version currently available of django-nested-admin in PyPI
is 2.1.8, however it seems to contain a bug that prevents bare bones
hearing creation. So temporalily install v2.1.11 from github which
fixes the problem.

Closes #128