### PR TITLE
Fix labels field

### DIFF
--- a/democracy/admin/__init__.py
+++ b/democracy/admin/__init__.py
@@ -3,11 +3,31 @@ from functools import partial
 from django.contrib import admin
 from django.db.models import TextField
 from django.utils.translation import ugettext_lazy as _
+from django.utils.encoding import force_text
+from django import forms
 from nested_admin.nested import NestedAdmin, NestedStackedInline
 
 from democracy import models
 from democracy.admin.widgets import Select2SelectMultiple, ShortTextAreaWidget, TinyMCE
 from democracy.enums import SectionType
+
+
+# Taken from https://github.com/asyncee/django-easy-select2/blob/master/easy_select2/forms.py
+class FixedModelForm(forms.ModelForm):
+    """
+    Simple child of ModelForm that removes the 'Hold down "Control" ...'
+    message that is enforced in select multiple fields.
+    See https://github.com/asyncee/django-easy-select2/issues/2
+    and https://code.djangoproject.com/ticket/9321
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(FixedModelForm, self).__init__(*args, **kwargs)
+
+        msg = force_text(_('Hold down "Control", or "Command" on a Mac, to select more than one.'))
+
+        for name, field in self.fields.items():
+            field.help_text = field.help_text.replace(msg, '')
 
 
 # Inlines
@@ -75,6 +95,7 @@ class HearingAdmin(NestedAdmin):
     formfield_overrides = {
         TextField: {'widget': ShortTextAreaWidget}
     }
+    form = FixedModelForm
 
     def formfield_for_manytomany(self, db_field, request=None, **kwargs):
         if db_field.name == "labels":

--- a/democracy/admin/widgets.py
+++ b/democracy/admin/widgets.py
@@ -46,7 +46,7 @@ class Select2SelectMultiple(SelectMultiple):
     SCRIPT_TEMPLATE = dedent("""
     <script type="text/javascript">
     addEvent(window, "load", function(e) {{
-        $("#{id}").select2();
+        $("#{id}").select2({{ width: '21em'}});
     }});
     </script>
     """)


### PR DESCRIPTION
Set fixed width for labels and disabled the default help text which was giving wrong instructions in admin UI. 

Refs #126 