### PR TITLE
Misc fixes

### DIFF
--- a/democracy/admin/__init__.py
+++ b/democracy/admin/__init__.py
@@ -111,6 +111,8 @@ class SectionInline(NestedStackedInline):
 
     def get_formset(self, request, obj=None, **kwargs):
         kwargs["formfield_callback"] = partial(self.formfield_for_dbfield, request=request, obj=obj)
+        if getattr(obj, "pk", None):
+            kwargs['extra'] = 0
         return super().get_formset(request, obj, **kwargs)
 
 

--- a/democracy/models/utils.py
+++ b/democracy/models/utils.py
@@ -31,6 +31,7 @@ def copy_hearing(old_hearing, **kwargs):
     for key, value in kwargs.items():
         setattr(new_hearing, key, value)
 
+    new_hearing.n_comments = 0
     new_hearing.save()
     new_hearing.labels = old_hearing.labels.all()
 
@@ -40,6 +41,7 @@ def copy_hearing(old_hearing, **kwargs):
         old_images = section.images.all()
         section.pk = None
         section.hearing = new_hearing
+        section.n_comments = 0
         section.save()
         for image in old_images:
             image.pk = None

--- a/democracy/tests/test_hearing.py
+++ b/democracy/tests/test_hearing.py
@@ -312,17 +312,20 @@ def test_hearing_copy(default_hearing, random_label):
     assert new_hearing.published is False
     assert new_hearing.title == 'overridden title'
 
-    # check num of new sections and section images and verify new section abstracts
     assert new_hearing.sections.count() == 3
     for i, new_section in enumerate(new_hearing.sections.all().order_by('abstract'), 1):
+        # each section should have 3 images, the correct abstract and no comments
         new_section.images.count() == 3
         assert new_section.abstract == 'Section %d abstract' % i
+        assert new_section.comments.count() == 0
+        assert new_section.n_comments == 0
 
     assert new_hearing.images.count() == 3
     assert random_label in new_hearing.labels.all()
 
     # there should be no comments for the new hearing
     assert new_hearing.comments.count() == 0
+    assert new_hearing.n_comments == 0
 
     # closure info section should not have been copied
     assert not new_hearing.sections.filter(type__identifier=InitialSectionType.CLOSURE_INFO).exists()


### PR DESCRIPTION
Reset comment cache when copying a hearing as a draft

Don't show extra section inline when editing a hearing