### PR TITLE
Admin soft delete

### DIFF
--- a/democracy/admin/__init__.py
+++ b/democracy/admin/__init__.py
@@ -182,6 +182,17 @@ class HearingAdmin(NestedModelAdmin, HearingGeoAdmin):
             })
     delete_selected.short_description = _('Delete selected %(verbose_name_plural)s')
 
+    def save_formset(self, request, form, formset, change):
+        objects = formset.save(commit=False)
+
+        for obj in formset.deleted_objects:
+            obj.soft_delete()
+
+        for obj in objects:
+            obj.save()
+
+        formset.save_m2m()
+
 
 class LabelAdmin(admin.ModelAdmin):
     exclude = ("public",)

--- a/democracy/admin/__init__.py
+++ b/democracy/admin/__init__.py
@@ -11,7 +11,7 @@ from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 from djgeojson.fields import GeoJSONFormField
 from leaflet.admin import LeafletGeoAdmin
-from nested_admin.nested import NestedAdmin, NestedStackedInline
+from nested_admin.nested import NestedModelAdmin, NestedStackedInline
 
 from democracy import models
 from democracy.admin.widgets import Select2SelectMultiple, ShortTextAreaWidget
@@ -128,7 +128,7 @@ class HearingGeoAdmin(LeafletGeoAdmin):
     }
 
 
-class HearingAdmin(NestedAdmin, HearingGeoAdmin):
+class HearingAdmin(NestedModelAdmin, HearingGeoAdmin):
 
     class Media:
         js = ("admin/ckeditor-nested-inline-fix.js",)

--- a/democracy/admin/__init__.py
+++ b/democracy/admin/__init__.py
@@ -5,6 +5,8 @@ from django import forms
 from django.conf import settings
 from django.contrib import admin
 from django.db.models import TextField
+from django.contrib.admin.utils import model_ngettext
+from django.core.exceptions import PermissionDenied
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 from djgeojson.fields import GeoJSONFormField
@@ -151,7 +153,7 @@ class HearingAdmin(NestedAdmin, HearingGeoAdmin):
         TextField: {'widget': ShortTextAreaWidget}
     }
     form = FixedModelForm
-    actions = ("copy_as_draft",)
+    actions = ("copy_as_draft", "delete_selected")
 
     def copy_as_draft(self, request, queryset):
         for hearing in queryset:
@@ -166,6 +168,19 @@ class HearingAdmin(NestedAdmin, HearingGeoAdmin):
         if db_field.name == "labels":
             kwargs["widget"] = Select2SelectMultiple
         return super().formfield_for_manytomany(db_field, request, **kwargs)
+
+    def delete_selected(self, request, queryset):
+        if not self.has_delete_permission(request):
+            raise PermissionDenied
+
+        hearing_count = queryset.count()
+        if hearing_count:
+            for hearing in queryset:
+                hearing.soft_delete()
+            self.message_user(request, _('Successfully deleted %(count)d %(items)s.') % {
+                'count': hearing_count, 'items': model_ngettext(self.opts, hearing_count)
+            })
+    delete_selected.short_description = _('Delete selected %(verbose_name_plural)s')
 
 
 class LabelAdmin(admin.ModelAdmin):

--- a/democracy/tests/test_admin.py
+++ b/democracy/tests/test_admin.py
@@ -1,0 +1,19 @@
+import pytest
+from django.core.urlresolvers import reverse
+from django.test.utils import override_settings
+
+from democracy.models import Hearing
+
+
+@pytest.mark.django_db
+@override_settings(LANGUAGE_CODE='en-us')
+def test_hearing_delete_action(admin_client, default_hearing):
+    change_url = reverse('admin:democracy_hearing_changelist')
+    data = {'action': 'delete_selected', '_selected_action': [default_hearing.pk]}
+    response = admin_client.post(change_url, data, follow=True)
+
+    assert response.status_code == 200
+    assert 'Successfully deleted 1 hearing.' in response.rendered_content
+
+    default_hearing = Hearing.objects.everything().get(pk=default_hearing.pk)
+    assert default_hearing.deleted is True

--- a/democracy/tests/test_admin.py
+++ b/democracy/tests/test_admin.py
@@ -17,3 +17,6 @@ def test_hearing_delete_action(admin_client, default_hearing):
 
     default_hearing = Hearing.objects.everything().get(pk=default_hearing.pk)
     assert default_hearing.deleted is True
+
+
+# TODO test section / section image inline soft delete somehow? it seems a bit complicated

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pyjwt
 django-enumfields==0.7.4
 pytz==2015.7
 jsonfield==1.0.3
-django-nested-admin==2.1.12
+django-nested-admin==3.0.2
 django-geojson==2.9.0
 django-leaflet==0.18.0
 django-ckeditor==5.0.3


### PR DESCRIPTION
Changed admin UI delete selected action to execute Hearing soft delete, and also added implementation for inlined Section and SectionImage soft deletion. Django-nested-admin needed to be updated to v3, which doesn't seem to cause any problems.

Closes #163