### PR TITLE
Add file uploading ability to CKEditor

### DIFF
--- a/democracy/admin/__init__.py
+++ b/democracy/admin/__init__.py
@@ -1,6 +1,5 @@
 from functools import partial
 
-from ckeditor.widgets import CKEditorWidget
 from django import forms
 from django.conf import settings
 from django.contrib import admin
@@ -9,6 +8,7 @@ from django.contrib.admin.utils import model_ngettext
 from django.core.exceptions import PermissionDenied
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
+from ckeditor_uploader.widgets import CKEditorUploadingWidget
 from djgeojson.fields import GeoJSONFormField
 from leaflet.admin import LeafletGeoAdmin
 from nested_admin.nested import NestedModelAdmin, NestedStackedInline
@@ -76,7 +76,7 @@ class SectionInline(NestedStackedInline):
     def formfield_for_dbfield(self, db_field, **kwargs):
         obj = kwargs.pop("obj", None)
         if db_field.name == "content":
-            kwargs["widget"] = CKEditorWidget
+            kwargs["widget"] = CKEditorUploadingWidget
             # Some initial value is needed for every section to workaround a bug in nested inlines
             # that causes an integrity error to be raised when a section image is added but the parent
             # section isn't saved.

--- a/democracy/views/upload.py
+++ b/democracy/views/upload.py
@@ -1,0 +1,89 @@
+import os
+
+from django.conf import settings
+from django.http import HttpResponse
+from django.shortcuts import render_to_response
+from django.template import RequestContext
+from django.views.decorators.csrf import csrf_exempt
+from ckeditor_uploader import image_processing
+from ckeditor_uploader import utils
+from ckeditor_uploader.views import get_files_browse_urls, ImageUploadView, SearchForm
+from django.utils.html import escape
+
+
+class AbsoluteUrlImageUploadView(ImageUploadView):
+    http_method_names = ['post']
+
+    def post(self, request, **kwargs):
+        """
+        Uploads a file and send back its URL to CKEditor.
+
+        Exactly the same as in django-ckeditor 5.0.3 except that creates
+        absolute URLs instead of relative ones.
+        """
+        uploaded_file = request.FILES['upload']
+
+        backend = image_processing.get_backend()
+        ck_func_num = escape(request.GET['CKEditorFuncNum'])
+
+        # Throws an error when an non-image file are uploaded.
+        if not getattr(settings, 'CKEDITOR_ALLOW_NONIMAGE_FILES', True):
+            try:
+                backend.image_verify(uploaded_file)
+            except utils.NotAnImageException:
+                return HttpResponse("""
+                    <script type='text/javascript'>
+                    window.parent.CKEDITOR.tools.callFunction({0}, '', 'Invalid file type.');
+                    </script>""".format(ck_func_num))
+
+        saved_path = self._save_file(request, uploaded_file)
+        self._create_thumbnail_if_needed(backend, saved_path)
+        url = utils.get_media_url(saved_path)
+
+        # this is the only customization to this function
+        url = request.build_absolute_uri(url)
+
+        # Respond with Javascript sending ckeditor upload url.
+        return HttpResponse("""
+        <script type='text/javascript'>
+            window.parent.CKEDITOR.tools.callFunction({0}, '{1}');
+        </script>""".format(ck_func_num, url))
+
+upload = csrf_exempt(AbsoluteUrlImageUploadView.as_view())
+
+
+def browse(request):
+    """
+    Uploaded file browse view.
+
+    Exactly the same as in django-ckeditor 5.0.3 except that creates
+    absolute URLs instead of relative ones.
+    """
+    files = get_files_browse_urls(request.user)
+
+    if request.method == 'POST':
+        form = SearchForm(request.POST)
+        if form.is_valid():
+            query = form.cleaned_data.get('q', '').lower()
+            files = list(filter(lambda d: query in d['visible_filename'].lower(), files))
+    else:
+        form = SearchForm()
+
+    show_dirs = getattr(settings, 'CKEDITOR_BROWSE_SHOW_DIRS', False)
+    dir_list = sorted(set(os.path.dirname(f['src']) for f in files), reverse=True)
+
+    # Ensures there are no objects created from Thumbs.db files - ran across this problem while developing on Windows
+    if os.name == 'nt':
+        files = [f for f in files if os.path.basename(f['src']) != 'Thumbs.db']
+
+    # this is the only customization to this function
+    for f in files:
+        f['src'] = request.build_absolute_uri(f['src'])
+
+    context = RequestContext(request, {
+        'show_dirs': show_dirs,
+        'dirs': dir_list,
+        'files': files,
+        'form': form
+    })
+    return render_to_response('ckeditor/browse.html', context)

--- a/kerrokantasi/settings/base.py
+++ b/kerrokantasi/settings/base.py
@@ -25,6 +25,7 @@ INSTALLED_APPS = (
     'djgeojson',
     'leaflet',
     'ckeditor',
+    'ckeditor_uploader',
     'helusers',
     'kerrokantasi',  # User model is project-wide
     'democracy',  # Reusable participatory democracy app
@@ -128,3 +129,5 @@ CKEDITOR_CONFIGS = {
         'contentsCss': ['%sckeditor/ckeditor/contents.css' % STATIC_URL, '.lead { font-weight: bold;}']
     },
 }
+CKEDITOR_UPLOAD_PATH = 'uploads/'
+CKEDITOR_IMAGE_BACKEND = 'pillow'

--- a/kerrokantasi/urls.py
+++ b/kerrokantasi/urls.py
@@ -3,12 +3,18 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.contrib.admin.views.decorators import staff_member_required
+from django.views.decorators.cache import never_cache
 from democracy import urls_v1
+from democracy.views.upload import browse, upload
 
 urlpatterns = [
     url(r'^v1/', include(urls_v1)),
     url(r'^nested_admin/', include(nested_admin_urls)),
     url(r'^admin/', include(admin.site.urls)),
+    url(r'^ckeditor/', include('ckeditor_uploader.urls')),
+    url(r'^upload/', staff_member_required(upload), name='ckeditor_upload'),
+    url(r'^browse/', never_cache(staff_member_required(browse)), name='ckeditor_browse'),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
By default django-ckeditor sets relative URLs for uploaded images
and for files selected using the editor's file browser, so those
views needed to be overidden to return absolute URLs.

Closes #150