### PR TITLE
A fix to Hearing images and comments removing migrations

### DIFF
--- a/democracy/migrations/0016_merge_comments.py
+++ b/democracy/migrations/0016_merge_comments.py
@@ -11,14 +11,14 @@ def forwards(apps, schema_editor):
     """
     Convert Hearing comments to introduction Section comments
     """
-    hearing_comments = apps.get_model('democracy', 'HearingComment').objects.all()
+    hearing_comments = apps.get_model('democracy', 'HearingComment').objects.filter(hearing__deleted=False)
     section_comment_model = apps.get_model('democracy', 'SectionComment')
 
     for hearing_comment in hearing_comments:
         data = {field: getattr(hearing_comment, field) for field in ('content', 'author_name', 'n_votes', 'created_by',
                                                                      'created_at', 'modified_at', 'modified_by')}
 
-        section = hearing_comment.hearing.sections.filter(type__identifier='introduction').first()
+        section = hearing_comment.hearing.sections.filter(type__identifier='introduction', deleted=False).first()
         if not section:
             raise CommandError("Hearing '%s' has HearingComment(s) but not an introduction section for those." %
                                hearing_comment.hearing_id)

--- a/democracy/migrations/0017_merge_images.py
+++ b/democracy/migrations/0017_merge_images.py
@@ -10,7 +10,7 @@ def forwards(apps, schema_editor):
     """
     Convert Hearing images to introduction Section images
     """
-    hearing_images = apps.get_model('democracy', 'HearingImage').objects.all()
+    hearing_images = apps.get_model('democracy', 'HearingImage').objects.filter(hearing__deleted=False)
     section_image_model = apps.get_model('democracy', 'SectionImage')
 
     for hearing_image in hearing_images:
@@ -18,7 +18,7 @@ def forwards(apps, schema_editor):
                                                                    'ordering', 'created_by', 'created_at',
                                                                    'modified_at', 'modified_by')}
 
-        section = hearing_image.hearing.sections.filter(type__identifier='introduction').first()
+        section = hearing_image.hearing.sections.filter(type__identifier='introduction', deleted=False).first()
         if not section:
             raise CommandError("Hearing '%s' has HearingImage(s) but not an introduction section for those." %
                                hearing_image.hearing_id)


### PR DESCRIPTION
Exclude soft deleted Hearings and Sections when converting Hearing
images and comments to main section images and comments. Soft deleted
ones should not be needed and they might cause problems when running
the migrations.