### PR TITLE
Allow POSTing comment's geometry

### DIFF
--- a/democracy/views/section_comment.py
+++ b/democracy/views/section_comment.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from django.utils.translation import ugettext as _
 from rest_framework import filters, serializers
 from rest_framework.exceptions import ValidationError
+from rest_framework.fields import JSONField
 from rest_framework.serializers import get_validation_error_detail
 from rest_framework.settings import api_settings
 
@@ -10,7 +11,7 @@ from democracy.models import SectionComment, Label
 from democracy.views.comment import COMMENT_FIELDS, BaseCommentViewSet, BaseCommentSerializer
 from democracy.views.label import LabelSerializer
 from democracy.pagination import DefaultLimitPagination
-from democracy.views.utils import filter_by_hearing_visible, NestedPKRelatedField
+from democracy.views.utils import filter_by_hearing_visible, GeoJSONField, NestedPKRelatedField
 
 
 class SectionCommentCreateSerializer(serializers.ModelSerializer):
@@ -24,10 +25,11 @@ class SectionCommentCreateSerializer(serializers.ModelSerializer):
         allow_null=True,
         expanded=True,
     )
+    geojson = GeoJSONField(required=False, allow_null=True)
 
     class Meta:
         model = SectionComment
-        fields = ['section', 'content', 'plugin_data', 'authorization_code', 'author_name', 'label']
+        fields = ['section', 'content', 'plugin_data', 'authorization_code', 'author_name', 'label', 'geojson']
 
     def to_internal_value(self, data):
         if data.get("plugin_data") is None:
@@ -58,6 +60,7 @@ class SectionCommentSerializer(BaseCommentSerializer):
     Serializer for comment added to section.
     """
     label = LabelSerializer(read_only=True)
+    geojson = JSONField(required=False, allow_null=True)
 
     class Meta:
         model = SectionComment

--- a/kerrokantasi/settings/base.py
+++ b/kerrokantasi/settings/base.py
@@ -100,6 +100,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': ['rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'],
     'DEFAULT_VERSION': '1',
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.NamespaceVersioning',
+    'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }
 
 


### PR DESCRIPTION
Update the comments' tests to support nested dictionary request
Add a GeoJSONSerializer that checks the geojson validity
Update the comment serializer to include the geojson serializer
Update a test to include geojson
Add some tests with invalid geojson submission

closes #223 