### PR TITLE
Add plugin_fullscreen field to Hearing data in API

### DIFF
--- a/democracy/tests/test_hearing.py
+++ b/democracy/tests/test_hearing.py
@@ -93,6 +93,22 @@ def test_list_top_5_hearings_check_title(api_client):
     assert '6' in objects[4]['title']
 
 
+@pytest.mark.parametrize('plugin_fullscreen', [
+    True,
+    False,
+])
+@pytest.mark.django_db
+def test_list_hearings_check_default_to_fullscreen(api_client, default_hearing, plugin_fullscreen):
+    main_section = default_hearing.get_main_section()
+    main_section.plugin_fullscreen = plugin_fullscreen
+    main_section.save()
+
+    response = api_client.get(list_endpoint)
+    data = get_data_from_response(response)
+    hearing = data['results'][0]
+    assert hearing['default_to_fullscreen'] == plugin_fullscreen
+
+
 @pytest.mark.django_db
 def test_get_next_closing_hearings(api_client):
     create_hearings(0)  # Clear out old hearings

--- a/democracy/views/hearing.py
+++ b/democracy/views/hearing.py
@@ -45,10 +45,14 @@ class HearingSerializer(serializers.ModelSerializer):
     main_image = serializers.SerializerMethodField()
     abstract = serializers.SerializerMethodField()
     contact_persons = ContactPersonSerializer(many=True, read_only=True)
+    default_to_fullscreen = serializers.SerializerMethodField()
+
+    def _get_main_section(self, hearing):
+        prefetched_mains = getattr(hearing, 'main_section_list', [])
+        return prefetched_mains[0] if prefetched_mains else hearing.get_main_section()
 
     def get_abstract(self, hearing):
-        prefetched_mains = getattr(hearing, 'main_section_list', [])
-        main_section = prefetched_mains[0] if prefetched_mains else hearing.get_main_section()
+        main_section = self._get_main_section(hearing)
         return main_section.abstract if main_section else ''
 
     def get_sections(self, hearing):
@@ -74,13 +78,17 @@ class HearingSerializer(serializers.ModelSerializer):
         else:
             return None
 
+    def get_default_to_fullscreen(self, hearing):
+        main_section = self._get_main_section(hearing)
+        return main_section.plugin_fullscreen if main_section else False
+
     class Meta:
         model = Hearing
         fields = [
             'abstract', 'title', 'id', 'borough', 'n_comments',
             'published', 'labels', 'open_at', 'close_at', 'created_at',
             'servicemap_url', 'sections',
-            'closed', 'geojson', 'organization', 'slug', 'main_image', 'contact_persons'
+            'closed', 'geojson', 'organization', 'slug', 'main_image', 'contact_persons', 'default_to_fullscreen',
         ]
 
 


### PR DESCRIPTION
The field is populated from main section plugin_fullscreen field.
This makes life easier for the frontend.