### PR TITLE
Allow to POST, PUT and PATCH Hearings

### DIFF
--- a/democracy/models/hearing.py
+++ b/democracy/models/hearing.py
@@ -109,3 +109,15 @@ class Hearing(StringIdBaseModel):
             return self.sections.get(type__identifier=InitialSectionType.MAIN)
         except ObjectDoesNotExist:
             return None
+
+    def is_visible_for(self, user):
+        if self.published and self.open_at < now():
+            return True
+        if not user.is_authenticated():
+            return False
+        if user.is_superuser:
+            return True
+        user_organization = user.get_default_organization()
+        if not (user_organization and self.organization):
+            return False
+        return user_organization == self.organization

--- a/democracy/tests/conftest.py
+++ b/democracy/tests/conftest.py
@@ -80,6 +80,12 @@ def default_hearing(john_doe, contact_person):
 
 
 @pytest.fixture()
+def default_label():
+    label = Label.objects.create(label='The Label')
+    return label
+
+
+@pytest.fixture()
 def random_hearing():
     if not Label.objects.exists():
         LabelFactory()

--- a/democracy/tests/conftest.py
+++ b/democracy/tests/conftest.py
@@ -142,6 +142,29 @@ def jane_doe_api_client(jane_doe):
 
 
 @pytest.fixture()
+def john_smith(default_organization):
+    """
+    John Smith is registered user working for an organization.
+    """
+    user = get_user_model().objects.filter(username="john_smith").first()
+    if not user:  # pragma: no branch
+        user = get_user_model().objects.create_user("john_smith", "john_smith@example.com", password="password")
+        user.admin_organizations.add(default_organization)
+    return user
+
+
+@pytest.fixture()
+def john_smith_api_client(john_smith):
+    """
+    John Smith is a registered user working for an organization; this is his API client.
+    """
+    api_client = APIClient()
+    api_client.force_authenticate(user=john_smith)
+    api_client.user = john_smith
+    return api_client
+
+
+@pytest.fixture()
 def admin_api_client(admin_user):
     api_client = APIClient()
     api_client.force_authenticate(user=admin_user)

--- a/democracy/tests/test_comment.py
+++ b/democracy/tests/test_comment.py
@@ -316,6 +316,7 @@ def test_56_add_comment_with_images_to_section(john_doe_api_client, default_hear
 
     assert len(new_comment_list) == len(old_comment_list) + 1
     new_comment = [c for c in new_comment_list if c["id"] == data["id"]][0]
+    new_comment['images'][0].pop('id')
     assert_common_keys_equal(new_comment, response_data)
     assert new_comment["is_registered"] == True
     assert new_comment["author_name"] is None

--- a/democracy/tests/test_comment.py
+++ b/democracy/tests/test_comment.py
@@ -12,14 +12,8 @@ from democracy.models import Hearing, Label, Section, SectionType
 from democracy.models.section import SectionComment
 from democracy.tests.conftest import default_comment_content
 from democracy.tests.utils import (
-    IMAGES, assert_common_keys_equal, get_data_from_response, get_geojson, get_hearing_detail_url, image_to_base64
+    assert_common_keys_equal, get_data_from_response, get_geojson, get_hearing_detail_url, image_test_json
 )
-
-test_image = {
-    'caption': 'Test',
-    'title': 'Test title',
-    'image': image_to_base64(IMAGES['ORIGINAL']),
-}
 
 
 def get_comment_data(**extra):
@@ -293,7 +287,7 @@ def test_56_add_comment_with_images_to_section(john_doe_api_client, default_hear
         old_comment_list = old_comment_list['results']
 
     # set section explicitly
-    comment_data = get_comment_data(section=section.pk, images=[test_image])
+    comment_data = get_comment_data(section=section.pk, images=[image_test_json()])
     response = john_doe_api_client.post(url, data=comment_data, format='json')
     data = get_data_from_response(response, status_code=201)
 
@@ -352,7 +346,7 @@ def test_56_add_comment_with_invalid_content_as_images(john_doe_api_client, defa
     section = default_hearing.sections.first()
     url, data = get_comments_url_and_data(default_hearing, section)
 
-    invalid_image = deepcopy(test_image)
+    invalid_image = image_test_json()
     invalid_image.update({"image": "not a b64 image"})
     comment_data = get_comment_data(section=section.pk, images=[invalid_image])
     response = john_doe_api_client.post(url, data=comment_data, format='json')
@@ -373,7 +367,7 @@ def test_56_add_comment_with_image_too_big(john_doe_api_client, default_hearing,
     section = default_hearing.sections.first()
     url, data = get_comments_url_and_data(default_hearing, section)
 
-    comment_data = get_comment_data(section=section.pk, images=[test_image])
+    comment_data = get_comment_data(section=section.pk, images=[image_test_json()])
     # 10 bytes max
     with override_settings(MAX_IMAGE_SIZE=10):
         response = john_doe_api_client.post(url, data=comment_data, format='json')

--- a/democracy/tests/test_comment.py
+++ b/democracy/tests/test_comment.py
@@ -11,8 +11,9 @@ from democracy.enums import Commenting, InitialSectionType
 from democracy.models import Hearing, Label, Section, SectionType
 from democracy.models.section import SectionComment
 from democracy.tests.conftest import default_comment_content
-from democracy.tests.test_images import get_hearing_detail_url
-from democracy.tests.utils import IMAGES, assert_common_keys_equal, get_data_from_response, get_geojson, image_to_base64
+from democracy.tests.utils import (
+    IMAGES, assert_common_keys_equal, get_data_from_response, get_geojson, get_hearing_detail_url, image_to_base64
+)
 
 test_image = {
     'caption': 'Test',

--- a/democracy/tests/test_hearing.py
+++ b/democracy/tests/test_hearing.py
@@ -210,7 +210,7 @@ def test_8_get_detail_labels(api_client):
 
     assert 'results' not in data
     assert len(data['labels']) is 3
-    assert label_one.label in data['labels']
+    assert {'id': label_one.id, 'label': label_one.label} in data['labels']
 
 
 @pytest.mark.django_db

--- a/democracy/tests/test_hearing.py
+++ b/democracy/tests/test_hearing.py
@@ -6,15 +6,116 @@ from django.utils.timezone import now
 
 from democracy.enums import InitialSectionType
 from democracy.models import (
-    Hearing, Label, Section, SectionComment, SectionImage, SectionType
+    Hearing, Label, Organization, Section, SectionComment, SectionImage, SectionType
 )
 from democracy.models.utils import copy_hearing
 from democracy.tests.utils import (
-    assert_datetime_fuzzy_equal, get_data_from_response, get_geojson, get_hearing_detail_url
+    assert_common_keys_equal, assert_datetime_fuzzy_equal, get_data_from_response, get_geojson,
+    get_hearing_detail_url, image_test_json
 )
 
 endpoint = '/v1/hearing/'
 list_endpoint = endpoint
+
+
+@pytest.fixture
+def valid_hearing_json(contact_person, default_label):
+    return {
+        "abstract": "",
+        "title": "My first hearing",
+        "id": "nD6aC5herQM3X1yi9aNQf6rGm6ZogAlC",
+        "borough": "Punavuori",
+        "n_comments": 0,
+        "published": True,
+        "labels": [{"id": default_label.id, "label": default_label.label}],
+        "open_at": "2016-09-29T11:39:12Z",
+        "close_at": "2016-09-29T11:39:12Z",
+        "created_at": "2016-10-04T10:30:38.066436Z",
+        "servicemap_url": "",
+        "sections": [
+            {
+                "type": "closure-info",
+                "commenting": 'none',
+                "published": True,
+                "title": "Section 3",
+                "abstract": "",
+                "content": "<p>Enter the introductioververn text for the hearing here.</p>",
+                "created_at": "2016-10-04T12:12:06.798574Z",
+                "created_by": None,
+                "images": [],
+                "n_comments": 0,
+                "plugin_identifier": "",
+                "plugin_data": "",
+                "type_name_singular": "sulkeutumistiedote",
+                "type_name_plural": "sulkeutumistiedotteet",
+            },
+            {
+                "commenting": 'none',
+                "published": True,
+                "title": "Section 1",
+                "abstract": "",
+                "content": "<p>Enter the introduction text for the hearing here.ve</p>",
+                "created_at": "2016-10-04T11:33:37.430091Z",
+                "created_by": None,
+                "images": [
+                    image_test_json(),
+                ],
+                "n_comments": 0,
+                "plugin_identifier": "",
+                "plugin_data": "",
+                "type_name_singular": "pääosio",
+                "type_name_plural": "pääosiot",
+                "type": "main"
+            },
+            {
+                "id": "3adn7MGkOJ8e4NlhsElxKggbfdmrSmVE",
+                "type": "part",
+                "commenting": 'none',
+                "published": True,
+                "title": "Section 2",
+                "abstract": "",
+                "content": "<p>Enter the introduction text for the hearing here.eve</p>",
+                "created_at": "2016-10-04T12:09:16.818364Z",
+                "created_by": None,
+                "images": [
+                    image_test_json(),
+                ],
+                "n_comments": 0,
+                "plugin_identifier": "",
+                "plugin_data": "",
+                "type_name_singular": "osa-alue",
+                "type_name_plural": "osa-alueet"
+            },
+        ],
+        "closed": True,
+        "organization": None,
+        "geojson": None,
+        "main_image": None,
+        "contact_persons": [{
+            "id": contact_person.id,
+            "name": contact_person.name,
+            "title": contact_person.title,
+            "phone": contact_person.phone,
+            "email": contact_person.email,
+            "organization": contact_person.organization.id,
+        }],
+    }
+
+
+def _update_hearing_data(data):
+    data.update({
+        "title": "Updating my first hearing",
+        "abstract": "A new abstract",
+        "borough": "Eira",
+        "n_comments": 10,
+        "published": False,
+        "open_at": "2016-10-29T11:39:12Z",
+        "close_at": "2016-10-29T11:39:12Z",
+        "created_at": "2015-06-04T10:30:38.066436Z",
+        "servicemap_url": "url",
+    })
+    data['sections'][0]['title'] = 'First section'
+    data['sections'][1]['images'][0]['caption'] = 'New image caption'
 
 
 def get_detail_url(id):
@@ -450,3 +551,208 @@ def test_hearing_filters(admin_api_client, default_hearing, updates, filters, ex
     response = admin_api_client.get(list_endpoint, filters)
     data = get_data_from_response(response)
     assert data['count'] == expected_count
+
+
+def assert_hearing_equals(data, posted, user, create=True):
+    posted['contact_persons'][0].update({'organization': 'The department for squirrel welfare'})
+    posted.pop('id')
+    created_at = data.pop('created_at')
+    if create:
+        assert_datetime_fuzzy_equal(created_at, now())
+    organization = data.pop('organization')
+    assert organization == user.get_default_organization().name
+    assert len(data['sections']) == len(posted['sections'])
+    sections_created = data.pop('sections')
+    sections_posted = posted.pop('sections')
+    assert_common_keys_equal(data, posted)
+    for section_created, section_posted in zip(sections_created, sections_posted):
+        section_created.pop('id', None)
+        created_at = section_created.pop('created_at')
+        if create:
+            assert_datetime_fuzzy_equal(created_at, now())
+            images = section_created.pop('images')
+            assert len(images) == len(section_posted['images'])
+        assert_common_keys_equal(section_created, section_posted)
+
+
+@pytest.mark.django_db
+def test_POST_hearing_anonymous_user(valid_hearing_json, api_client):
+    response = api_client.post(endpoint, data=valid_hearing_json, format='json')
+    data = get_data_from_response(response, status_code=401)
+    assert data == {'detail': 'Authentication credentials were not provided.'}
+
+
+@pytest.mark.django_db
+def test_POST_hearing_unauthorized_user(valid_hearing_json, john_doe_api_client):
+    response = john_doe_api_client.post(endpoint, data=valid_hearing_json, format='json')
+    data = get_data_from_response(response, status_code=403)
+    assert data == {"status": "User without organization cannot POST hearings."}
+
+
+# Test that a user can POST a hearing
+@pytest.mark.django_db
+def test_POST_hearing(valid_hearing_json, john_smith_api_client):
+    response = john_smith_api_client.post(endpoint, data=valid_hearing_json, format='json')
+    data = get_data_from_response(response, status_code=201)
+    assert data['organization'] == john_smith_api_client.user.get_default_organization().name
+    assert_hearing_equals(data, valid_hearing_json, john_smith_api_client.user)
+
+
+# Test that an anonymous user fails to update a hearing
+@pytest.mark.django_db
+def test_PUT_hearing_anonymous_user(valid_hearing_json, api_client, john_smith_api_client):
+    response = john_smith_api_client.post(endpoint, data=valid_hearing_json, format='json')
+    data = get_data_from_response(response, status_code=201)
+    _update_hearing_data(data)
+    response = api_client.put('%s%s/' % (endpoint, data['id']), data=data, format='json')
+    data = get_data_from_response(response, status_code=401)
+    assert data == {'detail': 'Authentication credentials were not provided.'}
+
+
+# Test that a user without organization fails to update a hearing
+@pytest.mark.django_db
+def test_PUT_hearing_unauthorized_user(valid_hearing_json, john_doe_api_client, john_smith_api_client):
+    response = john_smith_api_client.post(endpoint, data=valid_hearing_json, format='json')
+    data = get_data_from_response(response, status_code=201)
+    _update_hearing_data(data)
+    response = john_doe_api_client.put('%s%s/' % (endpoint, data['id']), data=data, format='json')
+    data = get_data_from_response(response, status_code=403)
+    assert data == {'status': 'User without organization cannot PUT hearings.'}
+
+
+# Test that a user cannot update a hearing from another organization
+@pytest.mark.django_db
+def test_PUT_hearing_other_organization_hearing(valid_hearing_json, john_smith_api_client):
+    response = john_smith_api_client.post(endpoint, data=valid_hearing_json, format='json')
+    data = get_data_from_response(response, status_code=201)
+    hearing = Hearing.objects.first()
+    hearing.organization = Organization.objects.create(name='The department for squirrel warfare')
+    hearing.save()
+    _update_hearing_data(data)
+    response = john_smith_api_client.put('%s%s/' % (endpoint, data['id']), data=data, format='json')
+    data = get_data_from_response(response, status_code=403)
+    assert data == {'detail': "User cannot update hearings from different organizations."}
+
+
+# Test that a user can update a hearing
+@pytest.mark.django_db
+def test_PUT_hearing(valid_hearing_json, john_smith_api_client):
+    response = john_smith_api_client.post(endpoint, data=valid_hearing_json, format='json')
+    data = get_data_from_response(response, status_code=201)
+    created_at = data['created_at']
+    _update_hearing_data(data)
+    response = john_smith_api_client.put('%s%s/' % (endpoint, data['id']), data=data, format='json')
+    updated_data = get_data_from_response(response, status_code=200)
+    assert updated_data['created_at'] == created_at
+    assert_hearing_equals(data, updated_data, john_smith_api_client.user, create=False)
+
+
+# Test that a user cannot update a hearing having no organization
+@pytest.mark.django_db
+def test_PUT_hearing_no_organization(valid_hearing_json, john_smith_api_client):
+    response = john_smith_api_client.post(endpoint, data=valid_hearing_json, format='json')
+    data = get_data_from_response(response, status_code=201)
+    _update_hearing_data(data)
+    hearing = Hearing.objects.filter(id=data['id']).first()
+    hearing.organization = None
+    hearing.save()
+    response = john_smith_api_client.put('%s%s/' % (endpoint, data['id']), data=data, format='json')
+    data = get_data_from_response(response, status_code=403)
+    assert data == {'detail': "User cannot update hearings from different organizations."}
+
+
+# Test that a user cannot steal an section while updating a hearing
+@pytest.mark.django_db
+def test_PUT_hearing_steal_section(valid_hearing_json, john_smith_api_client, default_hearing):
+    hearing = default_hearing
+    hearing.save()
+    other_hearing_section_id = hearing.get_main_section().id
+    response = john_smith_api_client.post(endpoint, data=valid_hearing_json, format='json')
+    data = get_data_from_response(response, status_code=201)
+    data['sections'][0]['id'] = other_hearing_section_id
+    response = john_smith_api_client.put('%s%s/' % (endpoint, data['id']), data=data, format='json')
+    updated_data = get_data_from_response(response, status_code=400)
+    assert ('The Hearing does not have a section with ID %s' % other_hearing_section_id) in updated_data['sections']
+
+
+# Test that the section are deleted upon updating the hearing
+@pytest.mark.django_db
+def test_PUT_hearing_delete_sections(valid_hearing_json, john_smith_api_client):
+    response = john_smith_api_client.post(endpoint, data=valid_hearing_json, format='json')
+    data = get_data_from_response(response, status_code=201)
+
+    closure_section_id = data['sections'][0]['id']
+    part_section_id = data['sections'][2]['id']
+    image_id = data['sections'][2]['images'][0]['id']
+    created_at = data['created_at']
+    data['sections'] = [data['sections'][1], ]
+    response = john_smith_api_client.put('%s%s/' % (endpoint, data['id']), data=data, format='json')
+    updated_data = get_data_from_response(response, status_code=200)
+    assert updated_data['created_at'] == created_at
+    assert_hearing_equals(data, updated_data, john_smith_api_client.user, create=False)
+    closure_section = Section.objects.deleted().filter(id=closure_section_id).first()
+    part_section = Section.objects.deleted().filter(id=part_section_id).first()
+    image = SectionImage.objects.deleted().filter(id=image_id).first()
+    assert closure_section
+    assert part_section
+    assert image
+
+
+# Test that a hearing cannot be created without 1 main section
+@pytest.mark.django_db
+def test_POST_hearing_no_main_section(valid_hearing_json, john_smith_api_client):
+    del(valid_hearing_json['sections'][1])
+    response = john_smith_api_client.post(endpoint, data=valid_hearing_json, format='json')
+    data = get_data_from_response(response, status_code=400)
+    assert 'A hearing must have exactly one main section' in data['sections']
+
+
+# Test that a hearing cannot be created with more than 1 main section
+@pytest.mark.django_db
+def test_POST_hearing_two_main_sections(valid_hearing_json, john_smith_api_client):
+    valid_hearing_json['sections'][2]['type'] = 'main'
+    response = john_smith_api_client.post(endpoint, data=valid_hearing_json, format='json')
+    data = get_data_from_response(response, status_code=400)
+    assert 'A hearing must have exactly one main section' in data['sections']
+
+
+# Test that a hearing cannot be created with more than 1 closure-info section
+@pytest.mark.django_db
+def test_POST_hearing_two_closure_sections(valid_hearing_json, john_smith_api_client):
+    valid_hearing_json['sections'][2]['type'] = 'closure-info'
+    response = john_smith_api_client.post(endpoint, data=valid_hearing_json, format='json')
+    data = get_data_from_response(response, status_code=400)
+    assert 'A hearing cannot have more than one closure info sections' in data['sections']
+
+
+# Test that a hearing cannot be updated without 1 main section
+@pytest.mark.django_db
+def test_PUT_hearing_no_main_section(valid_hearing_json, john_smith_api_client):
+    response = john_smith_api_client.post(endpoint, data=valid_hearing_json, format='json')
+    data = get_data_from_response(response, status_code=201)
+    data['sections'][1]['type'] = 'part'
+    response = john_smith_api_client.put('%s%s/' % (endpoint, data['id']), data=data, format='json')
+    data = get_data_from_response(response, status_code=400)
+    assert 'A hearing must have exactly one main section' in data['sections']
+
+
+# Test that a hearing cannot be updated with more than 1 main section
+@pytest.mark.django_db
+def test_PUT_hearing_two_main_sections(valid_hearing_json, john_smith_api_client):
+    response = john_smith_api_client.post(endpoint, data=valid_hearing_json, format='json')
+    data = get_data_from_response(response, status_code=201)
+    data['sections'][2]['type'] = 'main'
+    response = john_smith_api_client.put('%s%s/' % (endpoint, data['id']), data=data, format='json')
+    data = get_data_from_response(response, status_code=400)
+    assert 'A hearing must have exactly one main section' in data['sections']
+
+
+# Test that a hearing cannot be updated with more than 1 closure-info section
+@pytest.mark.django_db
+def test_PUT_hearing_two_closure_sections(valid_hearing_json, john_smith_api_client):
+    response = john_smith_api_client.post(endpoint, data=valid_hearing_json, format='json')
+    data = get_data_from_response(response, status_code=201)
+    data['sections'][2]['type'] = 'closure-info'
+    response = john_smith_api_client.put('%s%s/' % (endpoint, data['id']), data=data, format='json')
+    data = get_data_from_response(response, status_code=400)
+    assert 'A hearing cannot have more than one closure info sections' in data['sections']

--- a/democracy/tests/utils.py
+++ b/democracy/tests/utils.py
@@ -25,6 +25,14 @@ def image_to_base64(filename):
     return 'data:image/jpg;base64,%s' % base64.b64encode(buffered.getvalue()).decode('ascii')
 
 
+def image_test_json():
+    return {
+        'caption': 'Test',
+        'title': 'Test title',
+        'image': image_to_base64(IMAGES['ORIGINAL']),
+    }
+
+
 def create_image(instance, filename):
     image_class = BaseImage.find_subclass(parent_model=instance)
     image_field = image_class._meta.get_field("image")

--- a/democracy/tests/utils.py
+++ b/democracy/tests/utils.py
@@ -99,4 +99,8 @@ def assert_id_in_results(id, results, expected=True):
 
 def assert_common_keys_equal(dict1, dict2):
     for key in set(dict1) & set(dict2):
-        assert dict1[key] == dict2[key]
+        assert dict1[key] == dict2[key], 'dict1["%(key)s"] = %(v1)s while dict2["%(key)s"] = %(v2)s' % {
+            'key': key,
+            'v1': dict1[key],
+            'v2': dict2[key],
+        }

--- a/democracy/views/hearing.py
+++ b/democracy/views/hearing.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 import django_filters
 from django.db import transaction
 from django.db.models import Prefetch
-from django.utils.timezone import now
 from rest_framework import filters, permissions, response, serializers, status, viewsets
 from rest_framework.decorators import detail_route, list_route
 from rest_framework.fields import JSONField

--- a/democracy/views/hearing.py
+++ b/democracy/views/hearing.py
@@ -49,7 +49,7 @@ class HearingCreateUpdateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Hearing
         fields = [
-            'title', 'id', 'borough',
+            'title', 'id', 'borough', 'force_closed',
             'published', 'open_at', 'close_at', 'created_at',
             'servicemap_url', 'sections',
             'closed', 'geojson', 'organization', 'slug',

--- a/democracy/views/label.py
+++ b/democracy/views/label.py
@@ -4,13 +4,6 @@ from democracy.models import Label
 from democracy.pagination import DefaultLimitPagination
 
 
-class LabelFieldSerializer(serializers.RelatedField):
-    # Serializer for labels. Get label names instead of IDs.
-
-    def to_representation(self, value):
-        return value.label
-
-
 class LabelSerializer(serializers.ModelSerializer):
     class Meta:
         model = Label

--- a/democracy/views/section.py
+++ b/democracy/views/section.py
@@ -49,7 +49,7 @@ class SectionSerializer(serializers.ModelSerializer):
         model = Section
         fields = [
             'id', 'type', 'commenting', 'voting', 'published',
-            'title', 'abstract', 'content', 'created_at', 'created_by', 'images', 'n_comments',
+            'title', 'abstract', 'content', 'created_at', 'images', 'n_comments',
             'type_name_singular', 'type_name_plural',
             'plugin_identifier', 'plugin_data', 'plugin_iframe_url', 'plugin_fullscreen',
         ]

--- a/democracy/views/section.py
+++ b/democracy/views/section.py
@@ -4,7 +4,7 @@ from django.utils.timezone import now
 from rest_framework import filters, serializers, viewsets
 
 from democracy.enums import Commenting, InitialSectionType
-from democracy.models import Hearing, Section, SectionImage
+from democracy.models import Hearing, Section, SectionImage, SectionType
 from democracy.pagination import DefaultLimitPagination
 from democracy.utils.drf_enum_field import EnumField
 from democracy.views.base import AdminsSeeUnpublishedMixin, BaseImageSerializer
@@ -45,6 +45,24 @@ class SectionFieldSerializer(serializers.RelatedField):
 
     def to_representation(self, section):
         return SectionSerializer(section, context=self.context).data
+
+
+class SectionCreateUpdateSerializer(serializers.ModelSerializer):
+    """
+    Serializer for section create/update.
+    """
+    id = serializers.CharField(required=False)
+    type = serializers.SlugRelatedField(slug_field='identifier', queryset=SectionType.objects.all())
+    commenting = EnumField(enum_type=Commenting)
+
+    class Meta:
+        model = Section
+        fields = [
+            'id', 'type', 'commenting', 'published',
+            'title', 'abstract', 'content',
+            'plugin_identifier', 'plugin_data',
+            #'images',
+        ]
 
 
 class SectionViewSet(AdminsSeeUnpublishedMixin, viewsets.ReadOnlyModelViewSet):

--- a/democracy/views/utils.py
+++ b/democracy/views/utils.py
@@ -9,6 +9,7 @@ from django.contrib.gis.gdal.error import GDALException
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.db.models.query import QuerySet
+from django.utils.crypto import get_random_string
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers
@@ -169,9 +170,6 @@ class GeoJSONField(serializers.JSONField):
 class Base64ImageField(serializers.ImageField):
 
     def to_internal_value(self, data):
-        if not data:
-            raise ValidationError(_('"image" field is required.'))
-
         if isinstance(data, str) and data.startswith('data:image'):
             # base64 encoded image - decode
             try:
@@ -181,7 +179,7 @@ class Base64ImageField(serializers.ImageField):
 
             ext = format.split('/')[-1]  # guess file extension
 
-            data = ContentFile(base64.b64decode(imgstr), name='temp.' + ext)
+            data = ContentFile(base64.b64decode(imgstr), name='%s.%s' % (get_random_string(8), ext))
 
             # Do not limit image size if there is no settings for that
             if data.size <= getattr(settings, 'MAX_IMAGE_SIZE', data.size):

--- a/kerrokantasi/models.py
+++ b/kerrokantasi/models.py
@@ -9,4 +9,4 @@ class User(AbstractUser):
         return '{0} {1}'.format(self.first_name, self.last_name).strip()
 
     def get_default_organization(self):
-        return self.admin_organizations.order_by('created_time').first()
+        return self.admin_organizations.order_by('created_at').first()


### PR DESCRIPTION
Add serializers for Hearing create/update
Restrict PUT/PATCH to users of the same organization
Remove the unused section field "created_by" from section serializer
Allow user to GET unpublished hearings from their own organization
Add Tests