### PR TITLE
Listify INSTALLED_APPS and MIDDLEWARE_CLASSES

### DIFF
--- a/kerrokantasi/settings/base.py
+++ b/kerrokantasi/settings/base.py
@@ -8,7 +8,7 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -30,9 +30,9 @@ INSTALLED_APPS = (
     'democracy',  # Reusable participatory democracy app
     'parler',
     'django_filters',
-)
+]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE_CLASSES = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -42,7 +42,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
-)
+]
 
 ROOT_URLCONF = 'kerrokantasi.urls'
 


### PR DESCRIPTION
Seems they should always have been lists.
Also conversion to new middleware style needs to be done sometimes:
https://docs.djangoproject.com/en/1.11/topics/http/middleware/