### PR TITLE
Admin should see all hearings from all of their organizations

### DIFF
--- a/democracy/factories/organization.py
+++ b/democracy/factories/organization.py
@@ -1,0 +1,12 @@
+
+import factory
+import factory.fuzzy
+from democracy.models import Organization
+
+
+class OrganizationFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = Organization
+
+    name = factory.Faker('sentence')

--- a/democracy/views/utils.py
+++ b/democracy/views/utils.py
@@ -130,10 +130,10 @@ def filter_by_hearing_visible(queryset, request, hearing_lookup='hearing'):
     q = Q(**filters)
 
     if user.is_authenticated():
-        organization = user.get_default_organization()
-        if organization:
+        organizations = user.admin_organizations.all()
+        if organizations.exists():
             # regardless of publication status or date, admins will see everything from their organization
-            q |= Q(**{'%sorganization' % hearing_lookup: organization})
+            q |= Q(**{'%sorganization__in' % hearing_lookup: organizations})
 
     return queryset.filter(q)
 


### PR DESCRIPTION
this was already the case in `Hearing` `is_visible_for` but not in `views.utils.filter_by_hearing_visible`

Resolves #284 