### PR TITLE
Add setting for trusting X-Forwarded-Host header in Django

### DIFF
--- a/kerrokantasi/settings/base.py
+++ b/kerrokantasi/settings/base.py
@@ -26,6 +26,7 @@ env = environ.Env(
     SENTRY_ENVIRONMENT=(str,''),
     COOKIE_PREFIX=(str, 'kerrokantasi'),
     DEMOCRACY_UI_BASE_URL=(str, 'http://localhost:8086'),
+    TRUST_X_FORWARDED_HOST=(bool, False),
 )
 
 DEBUG = env('DEBUG')
@@ -62,6 +63,9 @@ SESSION_COOKIE_SECURE = True
 SESSION_COOKIE_PATH = '/{}'.format(env('COOKIE_PREFIX'))
 
 DEMOCRACY_UI_BASE_URL = env('DEMOCRACY_UI_BASE_URL')
+
+USE_X_FORWARDED_HOST = env('TRUST_X_FORWARDED_HOST')
+
 ### Settings below do not usually need changing
 
 INSTALLED_APPS = [


### PR DESCRIPTION
We had no way to enable trusting X-Forwarded-Host through environment variables. Adding that here.

Opinions on the setting name? I've essentially renamed the Django setting `USE_X_FORWARDED_HOST` to `TRUST_X_FORWARDED_HOST`? Perhaps it should be made a generic `TRUST_PROXY_HEADERS` setting?