### PR TITLE
Allow filtering Comments by created_at

### DIFF
--- a/democracy/tests/test_comment.py
+++ b/democracy/tests/test_comment.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
 from copy import deepcopy
+import urllib
 
 import pytest
 from django.test.utils import override_settings
@@ -821,6 +822,26 @@ def test_root_endpoint_filters(api_client, default_hearing, random_hearing):
     response = api_client.get('%s?hearing=%s' % (url, default_hearing.id))
     response_data = get_data_from_response(response)
     assert len(response_data['results']) == 9
+
+
+@pytest.mark.django_db
+def test_root_endpoint_timestamp_filters(api_client, default_hearing):
+    url = '/v1/comment/'
+    timestamp_now = now()
+    timestamp_comment = timestamp_now + datetime.timedelta(days=2)
+    timestamp_check = timestamp_now + datetime.timedelta(days=1)
+    comment_count = SectionComment.objects.count()
+    future_comment = SectionComment.objects.first()
+    future_comment.created_at = timestamp_comment
+    future_comment.save(update_fields=('created_at',))
+
+    response = api_client.get('%s?created_at__gt=%s' % (url, urllib.parse.quote(timestamp_check.isoformat())))
+    response_data = get_data_from_response(response)
+    assert len(response_data['results']) == 1
+
+    response = api_client.get('%s?created_at__lt=%s' % (url, urllib.parse.quote(timestamp_check.isoformat())))
+    response_data = get_data_from_response(response)
+    assert len(response_data['results']) == comment_count - 1
 
 
 @pytest.mark.django_db

--- a/democracy/views/section_comment.py
+++ b/democracy/views/section_comment.py
@@ -175,12 +175,14 @@ class RootSectionCommentSerializer(SectionCommentSerializer):
         fields = SectionCommentSerializer.Meta.fields + ['hearing']
 
 
-class CommentFilter(filters.FilterSet):
+class CommentFilter(django_filters.rest_framework.FilterSet):
     hearing = django_filters.CharFilter(name='section__hearing__id')
+    created_at__lt = django_filters.IsoDateTimeFilter(name='created_at', lookup_expr='lt')
+    created_at__gt = django_filters.rest_framework.IsoDateTimeFilter(name='created_at', lookup_expr='gt')
 
     class Meta:
         model = SectionComment
-        fields = ['authorization_code', 'section', 'hearing']
+        fields = ['authorization_code', 'created_at__lt', 'created_at__gt', 'section', 'hearing']
 
 
 # root level SectionComment endpoint


### PR DESCRIPTION
Closes #221 
Allow filtering of comments with created_at__gt and created_at__lt. 

The timestamp can be in ISO 8601 format (remember to quote the special characters such as `+` though).

Example queries:
`GET /v1/comment/?created_at__gt=2018-02-23T08:21:24.997290+00:00`
`GET /v1/comment/?created_at__lt=2018-02-23T08:21:24.997290Z`