### PR TITLE
Remove remnants of the old sentry SDK

### DIFF
--- a/kerrokantasi/settings/base.py
+++ b/kerrokantasi/settings/base.py
@@ -159,9 +159,6 @@ INSTALLED_APPS = [
     'django_filters',
 ]
 
-if env('SENTRY_DSN'):
-    INSTALLED_APPS.append('raven.contrib.django.raven_compat')
-
 MIDDLEWARE_CLASSES = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',


### PR DESCRIPTION
This would break startup if the old sentry SDK was not installed and Sentry was configured.