### PR TITLE
Soft delete comment images when comment is soft deleted

### DIFF
--- a/democracy/models/base.py
+++ b/democracy/models/base.py
@@ -89,20 +89,20 @@ class BaseModel(models.Model):
             self.modified_at = timezone.now()
         super().save(*args, **kwargs)
 
-    def soft_delete(self, using=None, user=None):
+    def soft_delete(self, user=None):
         self.deleted = True
         self.deleted_at = timezone.now()
         if user is not None and user.pk:
             self.deleted_by = user
-        self.save(update_fields=("deleted", "deleted_at", "deleted_by"), using=using)
+        self.save(update_fields=("deleted", "deleted_at", "deleted_by"))
 
-    def undelete(self, using=None):
+    def undelete(self):
         self.deleted = False
         self.deleted_at = None
         self.deleted_by = None
-        self.save(update_fields=("deleted", "deleted_at", "deleted_by"), using=using)
+        self.save(update_fields=("deleted", "deleted_at", "deleted_by"))
 
-    def delete(self, using=None):
+    def delete(self, **kwargs):
         raise NotImplementedError("This model does not support hard deletion")
 
     @classmethod

--- a/democracy/models/hearing.py
+++ b/democracy/models/hearing.py
@@ -147,9 +147,9 @@ class Hearing(StringIdBaseModel, TranslatableModel):
             return False
         return self.organization in user.admin_organizations.all()
 
-    def soft_delete(self, using=None, user=None):
+    def soft_delete(self, user=None):
         # we want deleted hearings to give way to new ones, the original slug from a deleted hearing
         # is now free to use
         self.slug += '-deleted'
         self.save()
-        super().soft_delete(using=using, user=user)
+        super().soft_delete(user=user)

--- a/democracy/models/section.py
+++ b/democracy/models/section.py
@@ -184,6 +184,10 @@ class SectionComment(Commentable, BaseComment):
     def soft_delete(self, user=None):
         for answer in self.poll_answers.all():
             answer.soft_delete(user=user)
+
+        for image in self.images.all():
+            image.soft_delete(user=user)
+
         super().soft_delete(user=user)
 
     def save(self, *args, **kwargs):

--- a/democracy/models/section.py
+++ b/democracy/models/section.py
@@ -181,10 +181,10 @@ class SectionComment(Commentable, BaseComment):
         verbose_name_plural = _('section comments')
         ordering = ('-created_at',)
 
-    def soft_delete(self, using=None, user=None):
+    def soft_delete(self, user=None):
         for answer in self.poll_answers.all():
             answer.soft_delete(user=user)
-        super().soft_delete(using=using, user=user)
+        super().soft_delete(user=user)
 
     def save(self, *args, **kwargs):
         # we may create a comment by referring to another comment instead of section explicitly

--- a/democracy/tests/conftest.py
+++ b/democracy/tests/conftest.py
@@ -114,6 +114,21 @@ def default_hearing(john_doe, contact_person, default_organization, default_proj
 
 
 @pytest.fixture()
+def comment_image(default_hearing):
+    """
+    Fixture for a comment image.
+    """
+    section = default_hearing.sections.all()[0]
+    comment = section.comments.all()[0]
+    return comment.images.create(
+        comment=comment,
+        image=ContentFile(b"image data", name='image1.jpg'),
+        width=640,
+        height=480,
+    )
+
+
+@pytest.fixture()
 def hearing__with_4_different_commenting(john_doe, contact_person, default_organization, default_project):
     """
     Fixture for a "default" hearing with four sections (one main, three other sections).


### PR DESCRIPTION
Previously images were not soft deleted when a comment was soft deleted. This PR adds soft deletion to also images and improves test coverage to check that both poll answers and images related to a comment are soft deleted.

Additionally removed unused usage of `using` from various places as it seemed unused.

https://helsinkisolutionoffice.atlassian.net/browse/KER-149
