### PR TITLE
KER-167: Add can_delete serializer field in SectionCommentSerializer

### DIFF
--- a/democracy/models/comment.py
+++ b/democracy/models/comment.py
@@ -102,6 +102,18 @@ class BaseComment(BaseModel):
         if self.parent_id:  # pragma: no branch
             self.parent.recache_n_comments()
 
+    def can_edit(self, request):
+        """
+        Whether the given request (HTTP or DRF) is allowed to edit this Comment.
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def can_delete(self, request):
+        """
+        Whether the given request (HTTP or DRF) is allowed to delete this Comment.
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
 
 def comment_recache(sender, instance, using, created, **kwargs):
     """

--- a/democracy/models/comment.py
+++ b/democracy/models/comment.py
@@ -102,25 +102,6 @@ class BaseComment(BaseModel):
         if self.parent_id:  # pragma: no branch
             self.parent.recache_n_comments()
 
-    def can_edit(self, request):
-        """
-        Whether the given request (HTTP or DRF) is allowed to edit this Comment.
-        """
-        if request.user.is_authenticated and self.created_by == request.user:
-            # also make sure the hearing is still commentable
-            try:
-                self.parent.check_commenting(request)
-            except ValidationError:
-                return False
-            return True
-        return False
-
-    def can_delete(self, request):
-        """
-        Whether the given request (HTTP or DRF) is allowed to delete this Comment.
-        """
-        return self.can_edit(request)
-
 
 def comment_recache(sender, instance, using, created, **kwargs):
     """

--- a/democracy/models/comment.py
+++ b/democracy/models/comment.py
@@ -106,8 +106,7 @@ class BaseComment(BaseModel):
         """
         Whether the given request (HTTP or DRF) is allowed to edit this Comment.
         """
-        is_authenticated = request.user.is_authenticated
-        if is_authenticated and self.created_by == request.user:
+        if request.user.is_authenticated and self.created_by == request.user:
             # also make sure the hearing is still commentable
             try:
                 self.parent.check_commenting(request)
@@ -115,6 +114,12 @@ class BaseComment(BaseModel):
                 return False
             return True
         return False
+
+    def can_delete(self, request):
+        """
+        Whether the given request (HTTP or DRF) is allowed to delete this Comment.
+        """
+        return self.can_edit(request)
 
 
 def comment_recache(sender, instance, using, created, **kwargs):

--- a/democracy/tests/integrationtest/test_comment.py
+++ b/democracy/tests/integrationtest/test_comment.py
@@ -1517,4 +1517,4 @@ def test_get_section_comment_edit_delete_rights(
 
     # Check that the properties are correct
     for key, value in expected_items.items():
-        assert data[0][key] == value
+        assert data[0][key] == value, f"Expected '{key}' to be {value} (was: {data[0][key]})"

--- a/democracy/views/section_comment.py
+++ b/democracy/views/section_comment.py
@@ -240,39 +240,10 @@ class SectionCommentSerializer(BaseCommentSerializer):
     def request(self):
         return self.context.get('request')
 
-    def is_commenting_allowed_in_parent(self, comment: SectionComment):
-        """
-        Whether commenting is allowed in the parent of the comment or not. Always False if no request is available.
-        """
-        if self.request is None:
-            return False
-
-        try:
-            comment.parent.check_commenting(self.request)
-        except ValidationError:
-            return False
-        return True
-
     def get_can_edit(self, comment: SectionComment):
-        """
-        Whether the comment can be edited or not. Always False if no request is available.
-        """
-        if self.request is None:
-            return False
-
-        # Is the user a staff member and the creator of the hearing?
-        if self.request.user.is_staff and self.request.user == comment.section.hearing.created_by:
-            return self.is_commenting_allowed_in_parent(comment)
-
         return comment.can_edit(self.request)
 
     def get_can_delete(self, comment: SectionComment):
-        """
-        Whether the comment can be deleted or not. Always False if no request is available.
-        """
-        if self.request is None:
-            return False
-
         return comment.can_delete(self.request)
 
     def to_representation(self, instance):


### PR DESCRIPTION
Add `can_delete` serializer method field in `SectionCommentSerializer` which tells whether the comment can be deleted or not.

Currently, the `can_edit` field covers both editing *and* deleting, so a more correct name would've been `can_delete_and_edit`. This PR separates these to their own fields, since they have different conditions. This is required for front-end representation; now it's all or nothing, but we want something from in-between as well.

Also move methods to their proper places, i.e. don't handle `SectionComment` stuff in `BaseComment`.

Related front-end PR: https://github.com/City-of-Helsinki/kerrokantasi-ui/pull/932