### PR TITLE
Fix comment edit rights

### DIFF
--- a/democracy/admin/__init__.py
+++ b/democracy/admin/__init__.py
@@ -422,6 +422,15 @@ class CommentAdmin(admin.ModelAdmin):
             obj.moderated = request.user.is_staff
         super().save_model(request, obj, form, change)
 
+    def has_change_permission(self, request, obj=None):
+        if obj and request.user == obj.section.hearing.created_by:
+            return False
+        return super().has_change_permission(request, obj=obj)
+
+    def has_delete_permission(self, request, obj=None):
+        if obj and request.user == obj.section.hearing.created_by:
+            return False
+        return super().has_delete_permission(request, obj=obj)
 
 class ProjectPhaseInline(TranslatableStackedInline, NestedStackedInline):
     model = models.ProjectPhase

--- a/democracy/models/section.py
+++ b/democracy/models/section.py
@@ -229,14 +229,6 @@ class SectionComment(Commentable, BaseComment):
         if request is None or not request.user.is_authenticated:
             return False
 
-        # Is creator of the hearing
-        if request.user == self.section.hearing.created_by:
-            return False
-
-        # Is admin
-        if request.user.is_staff:
-            return True
-
         # Is the user the creator of the comment?
         if request.user == self.created_by:
             return self.is_commenting_allowed_in_parent(request)
@@ -249,14 +241,6 @@ class SectionComment(Commentable, BaseComment):
         """
         if request is None or not request.user.is_authenticated:
             return False
-
-        # Is creator of the hearing
-        if request.user == self.section.hearing.created_by:
-            return False
-
-        # Is admin
-        if request.user.is_staff:
-            return True
 
         # Is the user the creator of the comment?
         if request.user == self.created_by:

--- a/democracy/tests/integrationtest/test_comment.py
+++ b/democracy/tests/integrationtest/test_comment.py
@@ -1473,7 +1473,7 @@ def test_section_comment_flag_with_proper_authentication(john_smith_api_client, 
 
 @pytest.mark.parametrize("user_api_client,comment_creator,hearing_creator,expected_items", [
     # Client's own comment in the client's hearing
-    ("john_doe_api_client", "john_doe", "john_doe", {"can_edit": False, "can_delete": False}),
+    ("john_doe_api_client", "john_doe", "john_doe", {"can_edit": True, "can_delete": True}),
     # Client's own comment in someone else's hearing
     ("john_doe_api_client", "john_doe", "jane_doe", {"can_edit": True, "can_delete": True}),
     # Someone else's comment in client's hearing
@@ -1481,7 +1481,7 @@ def test_section_comment_flag_with_proper_authentication(john_smith_api_client, 
     # Anonymous comment in client's hearing
     ("john_doe_api_client", None, "john_doe", {"can_edit": False, "can_delete": False}),
     # Someone else's comment in someone else's hearing as staff user
-    ("steve_staff_api_client", "john_doe", "john_doe", {"can_edit": True, "can_delete": True}),
+    ("steve_staff_api_client", "john_doe", "john_doe", {"can_edit": False, "can_delete": False}),
     # Someone else's comment in the client's hearing as staff user
     ("steve_staff_api_client", "john_doe", "steve_staff", {"can_edit": False, "can_delete": False}),
     # Anonymous comment in the client's hearing as staff user
@@ -1518,62 +1518,3 @@ def test_get_section_comment_edit_delete_rights(
     # Check that the properties are correct
     for key, value in expected_items.items():
         assert data[0][key] == value, f"Expected '{key}' to be {value} (was: {data[0][key]})"
-
-@pytest.mark.django_db
-def test_admin_can_edit_comments(john_doe_api_client, admin_api_client, default_hearing):
-    # Post a comment:
-    url = '/v1/hearing/%s/sections/%s/comments/' % (default_hearing.id, default_hearing.get_main_section().id)
-    response = john_doe_api_client.post(url, data=get_comment_data())
-    data = get_data_from_response(response, status_code=201)
-    comment_id = data["id"]
-
-    # Admin edits the comment:
-    response = admin_api_client.patch('%s%s/' % (url, comment_id), data={"content": "Hello"})
-    data = get_data_from_response(response, status_code=200)
-
-    assert data["content"] == "Hello"
-
-@pytest.mark.django_db
-def test_comment_editing_by_admin_returns_moderated_edited_flags(john_doe_api_client, admin_api_client, default_hearing):
-    # Post a comment:
-    url = '/v1/hearing/%s/sections/%s/comments/' % (default_hearing.id, default_hearing.get_main_section().id)
-    response = john_doe_api_client.post(url, data=get_comment_data())
-    data = get_data_from_response(response, status_code=201)
-    comment_id = data["id"]
-
-    # Admin edits the comment:
-    response = admin_api_client.patch('%s%s/' % (url, comment_id), data={"content": "Hello"})
-    data = get_data_from_response(response, status_code=200)
-
-    assert data["moderated"] == True
-    assert data["edited"] == True
-
-@pytest.mark.django_db
-def test_admin_can_delete_comments(john_doe_api_client, admin_api_client, default_hearing, comment_image, get_detail_url):
-    section = default_hearing.get_main_section()
-
-    comment = section.comments.all()[0]
-    assert comment_image.deleted is False
-
-    poll = SectionPollFactory(section=section, option_count=3, type=SectionPoll.TYPE_SINGLE_CHOICE)
-    option = poll.options.all().first()
-    answer = SectionPollAnswer.objects.create(option=option, comment=comment)
-    assert answer.deleted is False
-
-    url = get_detail_url(comment)
-    assert comment.images.all().count() == 1
-    assert comment.poll_answers.all().count() == 1
-
-    response = admin_api_client.delete(url)
-    assert response.status_code == 204
-
-    comment = SectionComment.objects.everything().get(id=comment.id)
-    assert comment.images.all().count() == 0
-    assert comment.poll_answers.all().count() == 0
-
-    comment_image.refresh_from_db()
-    assert comment_image.deleted is True
-    assert comment.deleted is True
-
-    answer.refresh_from_db()
-    assert answer.deleted is True

--- a/democracy/tests/integrationtest/test_comment_admin.py
+++ b/democracy/tests/integrationtest/test_comment_admin.py
@@ -1,0 +1,50 @@
+import pytest
+
+from democracy.models.section import SectionComment
+
+
+@pytest.mark.django_db
+def test_comment_delete_action(admin_client, admin_user, default_hearing):
+
+    default_hearing.created_by = admin_user
+    default_hearing.save()
+
+    comment = default_hearing.get_main_section().comments.all()[0]
+
+    url = f"/admin/democracy/sectioncomment/{comment.id}/delete/"
+    response = admin_client.delete(url)
+
+    assert response.status_code == 403
+
+    comment = SectionComment.objects.everything().get(id=comment.id)
+    assert comment.deleted is False
+
+@pytest.mark.django_db
+def test_comment_edit_action(admin_client, admin_user, default_hearing):
+
+    default_hearing.created_by = admin_user
+    default_hearing.save()
+
+    comment = default_hearing.get_main_section().comments.all()[0]
+
+    url = f"/admin/democracy/sectioncomment/{comment.id}/change/"
+    response = admin_client.post(url)
+
+    assert response.status_code == 403
+
+    comment = SectionComment.objects.everything().get(id=comment.id)
+    assert comment.edited is False
+
+@pytest.mark.django_db
+def test_comment_edited_by_admin(admin_client, admin_user, default_hearing):
+
+    comment = default_hearing.get_main_section().comments.all()[0]
+
+    data = {'content': 'test_data'}
+    url = f"/admin/democracy/sectioncomment/{comment.id}/change/"
+    response = admin_client.post(url, data)
+
+    comment = SectionComment.objects.everything().get(id=comment.id)
+    assert comment.content == 'test_data'
+    assert comment.edited is True
+    assert comment.moderated is True

--- a/democracy/views/comment.py
+++ b/democracy/views/comment.py
@@ -190,8 +190,6 @@ class BaseCommentViewSet(AdminsSeeUnpublishedMixin, viewsets.ModelViewSet):
         extra_params = {}
         # Comment has beed edited
         extra_params["edited"] = True
-        # Editor has been admin user
-        extra_params["moderated"] = request.user.is_staff
 
         # Use one serializer for update,
         partial = kwargs.pop('partial', False)


### PR DESCRIPTION
Comments can only be edited or deleted by their creator.

Restrict edit/delete rights in admin view so that hearing creators cannot edit comments within hearing.

Refs KER-179