### PR TITLE
update base image to use debian 'bookworm' instead of 'buster'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for Kerrokantasi backend
 # Attemps to provide for both local development and server usage
 
-FROM python:3.7-buster as appbase
+FROM python:3.7-bookworm as appbase
 
 RUN useradd -ms /bin/bash -d /kerrokantasi kerrokantasi
 
@@ -20,7 +20,7 @@ ENV PYTHONUNBUFFERED True
 
 # less & netcat-openbsd are there for in-container manual debugging
 # kerrokantasi needs gdal
-RUN apt-get update && apt-get install -y postgresql-client less netcat-openbsd gettext locales gdal-bin python-gdal python3-gdal
+RUN apt-get update && apt-get install -y postgresql-client less netcat-openbsd gettext locales gdal-bin python3-gdal
 
 # we need the Finnish locale built
 RUN sed -i 's/^# *\(fi_FI.UTF-8\)/\1/' /etc/locale.gen


### PR DESCRIPTION
Docker image is based on python image which uses old Debian, that has Critical level vulnerability: [CVE-2019-8457 OPEN THIS LINK IN A NEW TAB](https://security.snyk.io/vuln/SNYK-DEBIAN10-DB53-2825169)

Update base python image use tag `3.7-bookworm`, instead of using outdated `3.7-buster`.
Debian codename `buster` has seen it's EOL already: https://wiki.debian.org/DebianReleases

City of Helsinki SNYK finding: https://app.snyk.io/org/city-of-helsinki/project/4c7464fb-7e45-4c48-b6d8-4a2ea3ea4f7b