### PR TITLE
KER-202 KER-239 | Contact person endpoint can only be accessed by admins

### DIFF
--- a/democracy/tests/integrationtest/test_hearing.py
+++ b/democracy/tests/integrationtest/test_hearing.py
@@ -759,7 +759,7 @@ def test_preview_code_not_in_published(john_smith_api_client, default_organizati
     hearing_data = get_data_from_response(
         john_smith_api_client.get(get_detail_url(published_hearing.pk)), status_code=200
     )
-    print(hearing_data)
+
     assert hearing_data['preview_url'] == None
 
 

--- a/democracy/views/contact_person.py
+++ b/democracy/views/contact_person.py
@@ -1,8 +1,15 @@
-from rest_framework import mixins, permissions, response, serializers, status, viewsets
+from rest_framework import mixins, permissions, serializers, viewsets
 
 from democracy.models import ContactPerson, Organization
 from democracy.pagination import DefaultLimitPagination
 from democracy.views.utils import TranslatableSerializer
+
+
+class ContactPersonPermission(permissions.BasePermission):
+    message = "User without organization cannot access contact persons."
+
+    def has_permission(self, request, view):
+        return bool(hasattr(request.user, "get_default_organization") and request.user.get_default_organization())
 
 
 class ContactPersonSerializer(serializers.ModelSerializer, TranslatableSerializer):
@@ -15,26 +22,12 @@ class ContactPersonSerializer(serializers.ModelSerializer, TranslatableSerialize
 
     def create(self, validated_data):
         if not validated_data["organization"]:
-            validated_data["organization"] = self.context['request'].user.get_default_organization()
+            validated_data["organization"] = self.context["request"].user.get_default_organization()
         return super().create(validated_data)
 
 
 class ContactPersonViewSet(viewsets.ReadOnlyModelViewSet, mixins.CreateModelMixin, mixins.UpdateModelMixin):
     serializer_class = ContactPersonSerializer
     queryset = ContactPerson.objects.select_related("organization").order_by("name")
-    permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
+    permission_classes = [permissions.IsAuthenticated & ContactPersonPermission]
     pagination_class = DefaultLimitPagination
-
-    def create(self, request, **kwargs):
-        if not request.user or not request.user.get_default_organization():
-            return response.Response(
-                {'status': 'User without organization cannot POST contact persons.'}, status=status.HTTP_403_FORBIDDEN
-            )
-        return super().create(request, **kwargs)
-
-    def update(self, request, pk=None, partial=False):
-        if not request.user or not request.user.get_default_organization():
-            return response.Response(
-                {'status': 'User without organization cannot PUT contact persons.'}, status=status.HTTP_403_FORBIDDEN
-            )
-        return super().update(request, pk=pk, partial=partial)


### PR DESCRIPTION
This PR add more strict permissions for the contact person endpoint. Only authenticated organization admins will be able to use the entpoint. Also permission checks and related responses are refactored (for the viewset in question) to be more standard Django restframework.