### PR TITLE
Optimize Comments api

### DIFF
--- a/democracy/tests/integrationtest/test_comment.py
+++ b/democracy/tests/integrationtest/test_comment.py
@@ -3,6 +3,7 @@ import pytest
 import urllib
 from copy import deepcopy
 from django.test.utils import override_settings
+from django.urls import reverse
 from django.utils.encoding import force_text
 from django.utils.timezone import now
 from rest_framework import status
@@ -1568,9 +1569,28 @@ def test_delete_comment_comment(
     assert len(data['results'][0]['comments']) == 2
 
 @pytest.mark.django_db
-def test_section_comment_num_queries(django_assert_num_queries, john_doe_api_client, hearing_with_comments_on_comments):
-    url = f'/v1/comment/'
+def test_section_comment_num_queries(
+        django_assert_num_queries,
+        john_doe_api_client,
+        hearing_with_comments_on_comments
+):
+    url = reverse('comment-list')
 
     with django_assert_num_queries(8):
+        response = john_doe_api_client.get(url)
+        get_data_from_response(response, 200)
+
+@pytest.mark.django_db
+def test_hearing_sections_comment_num_queries(
+        django_assert_num_queries,
+        john_doe_api_client,
+        hearing_with_comments_on_comments
+):
+    url = reverse('comments-list', kwargs={
+        'hearing_pk': hearing_with_comments_on_comments.pk,
+        'comment_parent_pk': hearing_with_comments_on_comments.sections.first().pk
+    })
+
+    with django_assert_num_queries(6):
         response = john_doe_api_client.get(url)
         get_data_from_response(response, 200)

--- a/democracy/views/section_comment.py
+++ b/democracy/views/section_comment.py
@@ -463,16 +463,8 @@ class CommentViewSet(SectionCommentViewSet):
         """Returns all root-level comments, including deleted ones"""
 
         queryset = self.model.objects.everything()
-        queryset = queryset.select_related("created_by", "section").prefetch_related(
-            Prefetch(
-                "comments",
-                SectionComment.objects.everything().only("pk", "comment")
-            ),
-            "images",
-            "poll_answers",
-            "poll_answers__option",
-            "poll_answers__option__poll",
-        )
+        queryset = self.apply_select_and_prefetch(queryset)
+
         queryset = filter_by_hearing_visible(queryset, self.request, 'section__hearing')
         created_by = self.request.query_params.get('created_by', None)
         if created_by is not None and not self.request.user.is_anonymous:


### PR DESCRIPTION
`v1/hearing/whatever/sections/4bCl2TMEHoxiiTtdGIH7QEXzGhv4OwG2/comments/` (aka list-comments) was also super slow with large number of comments - apply same optimizations to that endpoint, unify the select/prefetch into a single method  and also add num query assert test for the comments endpoint