### PR TITLE
KER-278 | Bump packages alerted by snyk

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -38,7 +38,7 @@ coveralls==3.0.1
     # via -r requirements-dev.in
 distro==1.7.0
     # via -r requirements-dev.in
-django==3.2.21
+django==3.2.23
     # via
     #   -c requirements.txt
     #   django-debug-toolbar
@@ -134,7 +134,7 @@ typing-extensions==4.2.0
     # via
     #   -c requirements.txt
     #   black
-urllib3==2.0.4
+urllib3==2.0.7
     # via
     #   -c requirements.txt
     #   requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ cffi==1.14.5
     # via cryptography
 charset-normalizer==3.2.0
     # via requests
-cryptography==41.0.3
+cryptography==41.0.5
     # via social-auth-core
 decorator==5.1.1
     # via ipython
@@ -38,7 +38,7 @@ defusedxml==0.7.1
     #   social-auth-core
 deprecation==2.1.0
     # via django-helusers
-django==3.2.21
+django==3.2.23
     # via
     #   -r requirements.in
     #   django-cors-headers
@@ -145,7 +145,7 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pillow==10.0.0
+pillow==10.1.0
     # via
     #   -r requirements.in
     #   easy-thumbnails
@@ -207,7 +207,7 @@ requests-oauthlib==1.3.0
     # via social-auth-core
 rsa==4.7.2
     # via python-jose
-sentry-sdk==1.31.0
+sentry-sdk==1.34.0
     # via -r requirements.in
 six==1.15.0
     # via
@@ -238,7 +238,7 @@ typing-extensions==4.2.0
     #   ipython
 url-normalize==1.4.3
     # via requests-cache
-urllib3==2.0.4
+urllib3==2.0.7
     # via
     #   requests
     #   requests-cache


### PR DESCRIPTION

Snyk reported there to be some sec vurns in django, urllib3, cryptography and pillow in requirements and requirements-dev => let's bump'em.

Refs KER-278