### PR TITLE
refactor: update django-helusers and simplify oidc implementation

### DIFF
--- a/kerrokantasi/oidc.py
+++ b/kerrokantasi/oidc.py
@@ -1,25 +1,25 @@
 from django.conf import settings
-from helusers.oidc import ApiTokenAuthentication as HelApiTokenAuth
+from helusers.oidc import ApiTokenAuthentication
 
 
-class ApiTokenAuthentication(HelApiTokenAuth):
-    def __init__(self, *args, **kwargs):
-        super(ApiTokenAuthentication, self).__init__(*args, **kwargs)
-
+class StrongApiTokenAuthentication(ApiTokenAuthentication):
     def authenticate(self, request):
-        jwt_value = self.get_jwt_value(request)
-        if jwt_value is None:
+        result = super().authenticate(request)
+
+        if result is None:
             return None
 
-        payload = self.decode_jwt(jwt_value)
-        user, auth = super(ApiTokenAuthentication, self).authenticate(request)
+        user, auth = result
 
         # amr (Authentication Methods References) should contain the used auth
         # provider name e.g. suomifi
-        if payload.get("amr") in settings.STRONG_AUTH_PROVIDERS:
+        old_has_strong_auth = user.has_strong_auth
+        if auth.data.get("amr") in settings.STRONG_AUTH_PROVIDERS:
             user.has_strong_auth = True
         else:
             user.has_strong_auth = False
 
-        user.save()
-        return (user, auth)
+        if old_has_strong_auth != user.has_strong_auth:
+            user.save(update_fields=["has_strong_auth"])
+
+        return user, auth

--- a/kerrokantasi/oidc.py
+++ b/kerrokantasi/oidc.py
@@ -4,22 +4,18 @@ from helusers.oidc import ApiTokenAuthentication
 
 class StrongApiTokenAuthentication(ApiTokenAuthentication):
     def authenticate(self, request):
-        result = super().authenticate(request)
-
-        if result is None:
+        authentication_result = super().authenticate(request)
+        if authentication_result is None:
             return None
 
-        user, auth = result
+        user, auth = authentication_result
 
         # amr (Authentication Methods References) should contain the used auth
         # provider name e.g. suomifi
         old_has_strong_auth = user.has_strong_auth
-        if auth.data.get("amr") in settings.STRONG_AUTH_PROVIDERS:
-            user.has_strong_auth = True
-        else:
-            user.has_strong_auth = False
-
-        if old_has_strong_auth != user.has_strong_auth:
+        user.has_strong_auth = auth.data.get("amr") in settings.STRONG_AUTH_PROVIDERS
+        if user.has_strong_auth != old_has_strong_auth:
+            # Strong auth status has changed, update it
             user.save(update_fields=["has_strong_auth"])
 
         return user, auth

--- a/kerrokantasi/settings/base.py
+++ b/kerrokantasi/settings/base.py
@@ -265,7 +265,7 @@ CORS_URLS_REGEX = r"^/[a-z0-9-]*/?v1/.*$"
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
-        "kerrokantasi.oidc.ApiTokenAuthentication",
+        "kerrokantasi.oidc.StrongApiTokenAuthentication",
         "django.contrib.auth.backends.ModelBackend",
     ),
     "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),

--- a/kerrokantasi/tests/test_auth.py
+++ b/kerrokantasi/tests/test_auth.py
@@ -1,0 +1,38 @@
+from helusers._oidc_auth_impl import ApiTokenAuthentication
+from helusers.authz import UserAuthorization
+from unittest.mock import Mock, patch
+
+from kerrokantasi.oidc import StrongApiTokenAuthentication
+
+
+def test_api_token_authentication_none():
+    auth = StrongApiTokenAuthentication()
+    request = Mock()
+    with patch.object(ApiTokenAuthentication, "authenticate") as super_authenticate:
+        super_authenticate.return_value = None
+        assert auth.authenticate(request) is None
+
+
+def test_api_token_authentication_regular():
+    authentication = StrongApiTokenAuthentication()
+    user = Mock()
+    authorization = UserAuthorization(user, {"amr": "FOO"})
+    request = Mock()
+    with patch.object(ApiTokenAuthentication, "authenticate") as super_authenticate:
+        super_authenticate.return_value = (user, authorization)
+        result = authentication.authenticate(request)
+        assert result == (user, authorization)
+        assert user.has_strong_auth == False
+
+
+def test_api_token_authentication_strong(settings):
+    settings.STRONG_AUTH_PROVIDERS = ("FOO",)
+    authentication = StrongApiTokenAuthentication()
+    user = Mock()
+    authorization = UserAuthorization(user, {"amr": "FOO"})
+    request = Mock()
+    with patch.object(ApiTokenAuthentication, "authenticate") as super_authenticate:
+        super_authenticate.return_value = (user, authorization)
+        result = authentication.authenticate(request)
+        assert result == (user, authorization)
+        assert user.has_strong_auth == True

--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,7 @@ easy-thumbnails
 drf-nested-routers
 drf-oidc-auth<1
 xlsxwriter
-django-helusers==0.7.1
+django-helusers==0.9.0
 pyjwt
 django-enumfields>=0.8
 pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ django-filter==2.4.0
     # via -r requirements.in
 django-geojson==3.1.0
     # via -r requirements.in
-django-helusers==0.7.1
+django-helusers==0.9.0
     # via
     #   -r requirements.in
     #   helsinki-profile-gdpr-api


### PR DESCRIPTION
django-helusers 0.9.0 is marked as a requirement for keycloak migration.

Simplifies the derived ApiTokenAuthentication class. To reduce cognitive load, prefer to create new names for new classes
 rather than renaming common base classes via import statements.

Ref: KER-106