### PR TITLE
build: add commit message format requirements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 # Keep tool versions in sync with the versions in requirements-dev.txt
 default_language_version:
     python: python3
+default_install_hook_types: [pre-commit, commit-msg]
+default_stages: [pre-commit, manual]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -24,3 +26,9 @@ repos:
     hooks:
       - id: isort
         exclude: "migrations"
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.10.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg, manual]
+        additional_dependencies: ["@commitlint/config-conventional"]

--- a/README.md
+++ b/README.md
@@ -306,6 +306,14 @@ for code formatting and quality checking.
 run all the formatting tools as git hooks automatically before a
 commit.
 
+## Commit message format
+
+New commit messages must adhere to the [Conventional Commits](https://www.conventionalcommits.org/)
+specification, and line length is limited to 72 characters.
+
+When [`pre-commit`](https://pre-commit.com/) is in use, [`commitlint`](https://github.com/conventional-changelog/commitlint)
+checks new commit messages for the correct format.
+
 ### Git blame ignore refs
 
 Project includes a `.git-blame-ignore-revs` file for ignoring certain commits from `git blame`.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,10 @@
+const Configuration = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'header-max-length': [2, 'always', 72],
+    'body-max-line-length': [2, 'always', 72],
+    'body-leading-blank': [2, 'always'],
+  },
+};
+
+module.exports = Configuration;


### PR DESCRIPTION
## Description

From now on, all new commit messages must adhere to the [conventional commits spec](https://www.conventionalcommits.org/en/v1.0.0/) and their max line length is limited to 72 characters. The rules are enforced with [commitlint](https://commitlint.js.org/#/), which is run as a pre-commit hook and also as a stage in Azure pipelines.

There's a separate PR in Azure for the Azure side of things.

## Related Issue(s)

**[KER-292](https://helsinkisolutionoffice.atlassian.net/browse/KER-292)**


[KER-292]: https://helsinkisolutionoffice.atlassian.net/browse/KER-292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ