### PR TITLE
build: add compilemessages in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,8 @@ USER kerrokantasi
 # And the production image
 FROM appbase as production
 
+RUN django-admin compilemessages
+
 ENV DEBUG=False
 
 USER kerrokantasi


### PR DESCRIPTION
Running compilemessages after the container has been built requires write permissions for LC_MESSAGES. Compiling them during container image build shouldn't need separate write permissions.