### PR TITLE
KER-280 | GDPR additions and changes

### DIFF
--- a/democracy/models/gdpr_data_serialization_mixin.py
+++ b/democracy/models/gdpr_data_serialization_mixin.py
@@ -1,0 +1,14 @@
+from kerrokantasi.utils import get_current_request
+
+
+class FileFieldUrlSerializerMixin:
+    field_to_use_as_url_field = None  # Override in subclass.
+
+    @property
+    def url(self):
+        field = getattr(self, self.field_to_use_as_url_field, None)
+
+        if request := get_current_request():
+            return request.build_absolute_uri(field.url)
+
+        return field.url

--- a/democracy/models/section.py
+++ b/democracy/models/section.py
@@ -22,11 +22,11 @@ from democracy.models.base import (
 )
 from democracy.models.comment import BaseComment, recache_on_save
 from democracy.models.files import BaseFile
+from democracy.models.gdpr_data_serialization_mixin import FileFieldUrlSerializerMixin
 from democracy.models.hearing import Hearing
 from democracy.models.images import BaseImage
 from democracy.models.poll import BasePoll, BasePollAnswer, BasePollOption, poll_option_recache_on_save
 from democracy.plugins import get_implementation
-from democracy.utils.file_to_base64 import file_to_base64
 
 CLOSURE_INFO_ORDERING = -10000
 
@@ -141,13 +141,15 @@ class Section(Commentable, StringIdBaseModel, TranslatableModel, SerializableMix
         return get_implementation(self.plugin_identifier)
 
 
-class SectionImage(BaseImage, TranslatableModel, SerializableMixin):
+class SectionImage(BaseImage, TranslatableModel, SerializableMixin, FileFieldUrlSerializerMixin):
+    field_to_use_as_url_field = "image"
+
     serialize_fields = (
         {"name": "id"},
         {"name": "title"},
         {"name": "caption"},
         {"name": "alt_text"},
-        {"name": "image", "accessor": lambda x: file_to_base64(x)},
+        {"name": "url"},
         {"name": "published"},
         {"name": "created_at"},
         {"name": "modified_at"},
@@ -170,12 +172,14 @@ class SectionImage(BaseImage, TranslatableModel, SerializableMixin):
         ordering = ("ordering",)
 
 
-class SectionFile(BaseFile, TranslatableModel, SerializableMixin):
+class SectionFile(BaseFile, TranslatableModel, SerializableMixin, FileFieldUrlSerializerMixin):
+    field_to_use_as_url_field = "file"
+
     serialize_fields = (
         {"name": "id"},
         {"name": "title"},
         {"name": "caption"},
-        {"name": "file", "accessor": lambda x: file_to_base64(x)},
+        {"name": "url"},
         {"name": "published"},
         {"name": "created_at"},
         {"name": "modified_at"},
@@ -383,12 +387,14 @@ class SectionPollAnswer(BasePollAnswer, SerializableMixin):
         verbose_name_plural = _("section poll answers")
 
 
-class CommentImage(BaseImage, SerializableMixin):
+class CommentImage(BaseImage, SerializableMixin, FileFieldUrlSerializerMixin):
+    field_to_use_as_url_field = "image"
+
     serialize_fields = (
         {"name": "id"},
         {"name": "title"},
         {"name": "caption"},
-        {"name": "image", "accessor": lambda x: file_to_base64(x)},
+        {"name": "url"},
         {"name": "published"},
         {"name": "created_at"},
         {"name": "modified_at"},

--- a/kerrokantasi/models.py
+++ b/kerrokantasi/models.py
@@ -13,8 +13,8 @@ class User(AbstractUser, SerializableMixin):
         {"name": "last_name"},
         {"name": "email"},
         {"name": "has_strong_auth"},
-        {"name": "sectioncomment_created"},
-        {"name": "voted_democracy_sectioncomment"},
+        {"name": "sectioncomments"},
+        {"name": "voted_sectioncomments"},
         {"name": "followed_hearings"},
         {"name": "admin_organizations"},
         {"name": "hearing_created"},
@@ -22,6 +22,15 @@ class User(AbstractUser, SerializableMixin):
 
     nickname = models.CharField(max_length=50, blank=True)
     has_strong_auth = models.BooleanField(default=False)
+
+    # Properties for GDPR api serialization
+    @property
+    def sectioncomments(self):
+        return [s.serialize() for s in self.sectioncomment_created.everything().iterator()]
+
+    @property
+    def voted_sectioncomments(self):
+        return [s.serialize() for s in self.voted_democracy_sectioncomment.everything().iterator()]
 
     def __str__(self):
         return " - ".join([super().__str__(), self.get_display_name(), self.email])

--- a/kerrokantasi/settings/base.py
+++ b/kerrokantasi/settings/base.py
@@ -217,6 +217,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "social_django.middleware.SocialAuthExceptionMiddleware",
+    "kerrokantasi.gdpr.CurrentRequestMiddleware",
 ]
 
 # django-extensions is a set of developer friendly tools

--- a/kerrokantasi/tests/gdpr/test_gdpr_query.py
+++ b/kerrokantasi/tests/gdpr/test_gdpr_query.py
@@ -203,12 +203,14 @@ def _get_user_data(user: User) -> List[dict]:
         {"key": "EMAIL", "value": user.email},
         {"key": "HAS_STRONG_AUTH", "value": user.has_strong_auth},
         {
-            "key": "SECTIONCOMMENT_CREATED",
-            "children": [_get_section_comment_data(comment) for comment in user.sectioncomment_created.all()],
+            "key": "SECTIONCOMMENTS",
+            "value": [_get_section_comment_data(comment) for comment in user.sectioncomment_created.everything()],
         },
         {
-            "key": "VOTED_DEMOCRACY_SECTIONCOMMENT",
-            "children": [_get_section_comment_data(comment) for comment in user.voted_democracy_sectioncomment.all()],
+            "key": "VOTED_SECTIONCOMMENTS",
+            "value": [
+                _get_section_comment_data(comment) for comment in user.voted_democracy_sectioncomment.everything()
+            ],
         },
         {
             "key": "FOLLOWED_HEARINGS",
@@ -244,6 +246,12 @@ def test_get_user_information_from_gdpr_api(user, geojson_feature):
     comment_voted = SectionCommentFactory(section=section)
     comment_voted.voters.add(user)
     SectionPollAnswer.objects.create(comment=comment, created_by=user, option=poll_option)
+
+    deleted_comment = SectionCommentFactory(
+        section=section, created_by=user, author_name="Name of the Author", geojson=geojson_feature
+    )
+    deleted_comment.soft_delete()
+
     CommentImageFactory(comment=comment, created_by=user)
     hearing_followed = HearingFactory()
     hearing_followed.followers.add(user)

--- a/kerrokantasi/utils.py
+++ b/kerrokantasi/utils.py
@@ -1,0 +1,4 @@
+def get_current_request():
+    from kerrokantasi.gdpr import _thread_locals
+
+    return getattr(_thread_locals, "request", None)


### PR DESCRIPTION
Adds following changes to gdpr api get

- Show (soft)deleted comments
- Renders file and image urls instead of bytes
   - Added custom middleware for accessing the request so that the url could be built.


Refs KER-280
