### PR TITLE
Fix crash when creating a hearing with existing file references, add option for creating new files/images by reference

### DIFF
--- a/democracy/tests/integrationtest/test_hearing.py
+++ b/democracy/tests/integrationtest/test_hearing.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import pytest
+from copy import deepcopy
 from django.utils.encoding import force_text
 from django.utils.timezone import now
 
@@ -21,13 +22,18 @@ from democracy.models import (
 from democracy.models.utils import copy_hearing
 from democracy.tests.conftest import default_lang_code
 from democracy.tests.utils import (
+    FILES,
     assert_common_keys_equal,
     assert_datetime_fuzzy_equal,
+    file_to_bytesio,
     get_data_from_response,
+    get_file_path,
     get_hearing_detail_url,
+    get_nested,
     sectionfile_base64_test_data,
     sectionimage_test_json,
 )
+from democracy.utils.file_to_base64 import file_to_base64
 from kerrokantasi.tests.conftest import get_feature_with_geometry
 
 endpoint = "/v1/hearing/"
@@ -1066,6 +1072,126 @@ def test_POST_hearing(valid_hearing_json, john_smith_api_client):
     data = get_data_from_response(response, status_code=201)
     assert data["organization"] == john_smith_api_client.user.get_default_organization().name
     assert_hearing_equals(data, valid_hearing_json, john_smith_api_client.user)
+
+
+@pytest.mark.django_db
+def test_POST_hearing_with_file_upload(valid_hearing_json, john_smith_api_client):
+    # Upload a file before creating the hearing, similar to how you would upload the file
+    # in the creation form before submitting the form.
+    data = get_data_from_response(
+        john_smith_api_client.post(
+            "/v1/file/",
+            data={
+                "title": {
+                    "fi": "Testi",
+                    "en": "Test",
+                },
+                "caption": {},
+                "file": file_to_base64(file_to_bytesio(FILES["PDF"])),
+            },
+        ),
+        status_code=201,
+    )
+
+    # We have other tests for the file upload, so we can assume that the file upload works.
+    # Add the freshly uploaded file to the hearing data.
+    valid_hearing_json["sections"][0]["files"] = [data]
+
+    response = john_smith_api_client.post(endpoint, data=valid_hearing_json, format="json")
+    data = get_data_from_response(response, status_code=201)
+
+    assert_hearing_equals(data, valid_hearing_json, john_smith_api_client.user)
+
+
+@pytest.mark.django_db
+def test_POST_save_hearing_as_new(valid_hearing_json, john_smith_api_client):
+    # Modify the default hearing data to simplify testing.
+    valid_hearing_json["title"] = {"en": "Hearing"}
+    valid_hearing_json["sections"] = [
+        {
+            "voting": "registered",
+            "commenting": "none",
+            "commenting_map_tools": "none",
+            "title": {
+                "en": "Section",
+            },
+            "abstract": {},
+            "content": {},
+            "images": [
+                sectionimage_test_json(),
+            ],
+            "files": [
+                sectionfile_base64_test_data(),
+            ],
+            "questions": [
+                {
+                    "type": "multiple-choice",
+                    "is_independent_poll": False,
+                    "text": {"en": "Question"},
+                    "options": [
+                        {"text": {"en": "1"}},
+                        {"text": {"en": "2"}},
+                    ],
+                }
+            ],
+            "plugin_identifier": "",
+            "plugin_data": "",
+            "type_name_singular": "pääosio",
+            "type_name_plural": "pääosiot",
+            "type": "main",
+        },
+    ]
+    response = john_smith_api_client.post(endpoint, data=valid_hearing_json, format="json")
+    hearing = get_data_from_response(response, status_code=201)
+
+    # Do some edits before saving as new...
+    save_as_new_payload = deepcopy(hearing)
+    # Set ids to None.
+    save_as_new_payload["id"] = None
+    save_as_new_payload["sections"][0]["id"] = None
+    question = save_as_new_payload["sections"][0]["questions"][0]
+    question["id"] = None
+    for option in question["options"]:
+        option["id"] = None
+    # Files and images need to have a reference ID set to the original ID.
+    file = save_as_new_payload["sections"][0]["files"][0]
+    file["reference_id"] = file["id"]
+    file["id"] = None
+    image = save_as_new_payload["sections"][0]["images"][0]
+    image["reference_id"] = image["id"]
+    image["id"] = None
+
+    response = john_smith_api_client.post(endpoint, data=save_as_new_payload, format="json")
+    new_hearing = get_data_from_response(response, status_code=201)
+
+    # Assert for content that should match between the original and the new hearing.
+    for keys in (
+        ("title",),
+        ("sections", 0, "title"),
+        ("sections", 0, "images", 0, "url"),
+        ("sections", 0, "questions", 0, "text"),
+        ("sections", 0, "questions", 0, "options", 0, "text"),
+        ("sections", 0, "questions", 0, "options", 1, "text"),
+    ):
+        assert (a := get_nested(hearing, keys)) == (
+            b := get_nested(new_hearing, keys)
+        ), f'{keys} should match ("{a}" != "{b}")'
+
+    # Assert for content that should *not* match between the original and the new hearing.
+    for keys in (
+        ("id",),
+        ("sections", 0, "id"),
+        ("sections", 0, "images", 0, "id"),
+        ("sections", 0, "files", 0, "id"),
+        # this is a url to the resource, so unlike with an image, it should not match
+        ("sections", 0, "files", 0, "url"),
+        ("sections", 0, "questions", 0, "id"),
+        ("sections", 0, "questions", 0, "options", 0, "id"),
+        ("sections", 0, "questions", 0, "options", 1, "id"),
+    ):
+        assert (a := get_nested(hearing, keys)) != (
+            b := get_nested(new_hearing, keys)
+        ), f'{keys} should not match ("{a}" == "{b}")'
 
 
 @pytest.mark.django_db

--- a/democracy/tests/utils.py
+++ b/democracy/tests/utils.py
@@ -3,6 +3,7 @@ import os
 from django.utils.dateparse import parse_datetime
 from io import BytesIO
 from PIL import Image
+from typing import Iterable, Mapping
 
 from democracy.models.files import BaseFile
 from democracy.models.images import BaseImage
@@ -201,3 +202,11 @@ def assert_common_keys_equal(dict1, dict2):
             "v1": dict1[key],
             "v2": dict2[key],
         }
+
+
+def get_nested(data: Mapping, keys: Iterable):
+    """Get a nested value from a mapping using an iterable of keys."""
+    val = data
+    for key in keys:
+        val = val[key]
+    return val

--- a/democracy/views/base.py
+++ b/democracy/views/base.py
@@ -66,6 +66,8 @@ class BaseFileSerializer(AbstractSerializerMixin, serializers.ModelSerializer):
         fields = ["title", "url", "caption"]
 
     def get_url(self, obj):
+        if not obj.pk:
+            return None
         url = reverse("serve_file", kwargs={"filetype": self.filetype, "pk": obj.pk})
         if not self.context:
             raise NotImplementedError("Not implemented")  # pragma: no cover


### PR DESCRIPTION
TL;DR:
- replace copy-or-update logic in CreateUpdateSerializers create-or-update
- fix crash when creating a hearing with existing file references (i.e. upload files before creating a hearing and then posting that hearing with the pre-uploaded file)
- add a write-only `reference_id` field for files/images when creating new hearings

---

Some of the serializers worked with a update-or-copy logic instead of update-or-create (as their name would imply), which was added in PR https://github.com/City-of-Helsinki/kerrokantasi/pull/363 (https://github.com/City-of-Helsinki/kerrokantasi/commit/6c97234277c1f07949858304f0060e0271e7e6e0).

This caused an error whenever you're creating a new hearing and have already uploaded a file to a section (via the form's file upload functionality). Added a test to confirm that this scenario functions correctly now. The crash is fixed (or should be fixed) in the PR's commit 32774cf664f9303570add11e7c9c1fc33604c5e1, but leaves the rather strange serializer logic in place. 

E.g. if you want to create a new hearing using an existing hearing as a base, you'll have to remove the IDs from the hearing and the sections, but *need* to have the IDs for files and images.

Since this works on an update-or-copy basis, it means that you *cannot* use an existing instance for a file or an image on creation; if you do, it gets copied. The only other way to use existing instances is to first create the hearing *without* the files/images and then update the hearing.

This PR replaces that copy (or rather, save as copy) logic with create logic (so create-or-update rather than copy-or-update) and moves the burden to the consumer of the API, i.e. the consumer needs to remove the IDs from the data they want to copy.

However, files and images still need a reference to the instance they're copied from, so add a new field "reference_id" for this. Not the perfect solution, but this allows the user to create new files or images based on existing instances while retaining some kind of sanity with the API.

In its current state, it's meant for "save as new" type of situations. This means that if the pk is set for an image/file, then it will ignore the reference_id, i.e. you cannot update an existing instance using reference_id.

Also fixes a crash when trying to get a URL for a file the user is trying to copy by adding a check for whether the file has a PK or not. E.g. try to copy a file -> get reference file from database -> set pk to `None` -> validation checks for URL -> URL requires a PK -> 💥

Also note that while the previous code referred to copying in comments and in its associated commit/PR, it's actually saving as a copy/saving as new rather than just copying. This is a **very** important distinction, since it means that you have the option to edit the hearing before creating a copy of it instead of just creating a clone of another hearing.

Refs KER-351

Related front-end PR: https://github.com/City-of-Helsinki/kerrokantasi-ui/pull/1025