### PR TITLE
fix: copy files in copy_hearing function

### DIFF
--- a/democracy/models/utils.py
+++ b/democracy/models/utils.py
@@ -60,6 +60,12 @@ def copy_hearing(old_hearing, **kwargs):
             image.section = section
             image.save()
             _copy_translations(image, old_image)
+        for old_file in old_section.files.all():
+            file = deepcopy(old_file)
+            file.pk = None
+            file.section = section
+            file.save()
+            _copy_translations(file, old_file)
         for old_poll in old_polls:
             old_options = old_poll.options.all()
             poll = deepcopy(old_poll)

--- a/democracy/tests/integrationtest/test_hearing.py
+++ b/democracy/tests/integrationtest/test_hearing.py
@@ -900,7 +900,7 @@ def test_hearing_copy(default_hearing, random_label):
     assert new_hearing.sections.count() == 3
     for i, new_section in enumerate(new_hearing.sections.all().order_by("translations__abstract"), 1):
         # each section should have 3 images, the correct abstract and no comments
-        new_section.images.count() == 3
+        assert new_section.images.count() == 3
         assert new_section.abstract == "Section %d abstract" % i
         assert new_section.comments.count() == 0
         assert new_section.n_comments == 0

--- a/democracy/tests/integrationtest/test_hearing.py
+++ b/democracy/tests/integrationtest/test_hearing.py
@@ -899,8 +899,9 @@ def test_hearing_copy(default_hearing, random_label):
 
     assert new_hearing.sections.count() == 3
     for i, new_section in enumerate(new_hearing.sections.all().order_by("translations__abstract"), 1):
-        # each section should have 3 images, the correct abstract and no comments
+        # each section should have 3 images, 1 file, the correct abstract and no comments
         assert new_section.images.count() == 3
+        assert new_section.files.count() == 1
         assert new_section.abstract == "Section %d abstract" % i
         assert new_section.comments.count() == 0
         assert new_section.n_comments == 0


### PR DESCRIPTION
This PR makes the copy hearing action in Django Admin's hearing listing copy files as well.

Note that the hearings in Django Admin don't seem to work very well and I'm not even sure if it's used at all, but I encountered this bug while doing another change and fixed it. However, I decided to scrap the idea that used this function and made this fix into its own PR (rather than throwing it away).

Refs KER-359