### PR TITLE
KER-360: Fix following filter

### DIFF
--- a/democracy/tests/integrationtest/test_hearing.py
+++ b/democracy/tests/integrationtest/test_hearing.py
@@ -457,6 +457,19 @@ def test_filter_hearings_by_following(john_doe_api_client):
     assert len(data["results"]) == 3
 
 
+@pytest.mark.django_db
+def test_filter_hearings_by_following_anonymous_user(api_client, john_doe):
+    Hearing.objects.create(title="hearing")
+    hearing_with_follower = Hearing.objects.create(title="hearing with follower")
+    hearing_with_follower.followers.add(john_doe)
+
+    response = api_client.get(list_endpoint, data={"following": True})
+
+    data = get_data_from_response(response)
+    # Should return all hearings.
+    assert len(data["results"]) == 2
+
+
 @pytest.mark.parametrize(
     "plugin_fullscreen",
     [

--- a/democracy/views/hearing.py
+++ b/democracy/views/hearing.py
@@ -52,6 +52,12 @@ class HearingFilterSet(django_filters.rest_framework.FilterSet):
     label = django_filters.Filter(
         field_name="labels__id", lookup_expr="in", distinct=True, widget=django_filters.widgets.CSVWidget
     )
+    following = django_filters.BooleanFilter(method="filter_following")
+
+    def filter_following(self, queryset, name, value):
+        if value and self.request.user.is_authenticated:
+            return queryset.filter(followers=self.request.user)
+        return queryset
 
     class Meta:
         model = Hearing
@@ -456,10 +462,6 @@ class HearingViewSet(AdminsSeeUnpublishedMixin, viewsets.ModelViewSet):
         next_closing = self.request.query_params.get("next_closing", None)
         open = self.request.query_params.get("open", None)
         created_by = self.request.query_params.get("created_by", None)
-        following = self.request.query_params.get("following", None)
-
-        if following is not None and self.request.user.is_authenticated:
-            queryset = queryset.filter(followers=self.request.user)
 
         if created_by is not None and self.request.user:
             if created_by.lower() == "me":

--- a/democracy/views/hearing.py
+++ b/democracy/views/hearing.py
@@ -458,7 +458,7 @@ class HearingViewSet(AdminsSeeUnpublishedMixin, viewsets.ModelViewSet):
         created_by = self.request.query_params.get("created_by", None)
         following = self.request.query_params.get("following", None)
 
-        if following is not None and self.request.user:
+        if following is not None and self.request.user.is_authenticated:
             queryset = queryset.filter(followers=self.request.user)
 
         if created_by is not None and self.request.user:


### PR DESCRIPTION
Using the `following` filter unauthenticated causes a server error. This PR fixes it and also makes it a part of `HearingFilterSet`.