### PR TITLE
KER-366: Refactor hearing filters, remove next_closing filter

### DIFF
--- a/democracy/factories/hearing.py
+++ b/democracy/factories/hearing.py
@@ -36,6 +36,13 @@ class CommentImageFactory(factory.django.DjangoModelFactory):
         model = CommentImage
 
 
+class MinimalHearingFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Hearing
+
+    title = factory.Faker("sentence")
+
+
 class HearingFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Hearing

--- a/democracy/tests/integrationtest/test_hearing.py
+++ b/democracy/tests/integrationtest/test_hearing.py
@@ -490,33 +490,6 @@ def test_list_hearings_check_default_to_fullscreen(api_client, default_hearing, 
 
 
 @pytest.mark.django_db
-def test_get_next_closing_and_open_hearings(api_client):
-    create_hearings(0)  # Clear out old hearings
-    Hearing.objects.create(title="Gone", close_at=now() - datetime.timedelta(days=1))  # Closed hearing
-    Hearing.objects.create(title="Gone too", close_at=now() - datetime.timedelta(days=2))  # Closed hearing
-    future_hearing_1 = Hearing.objects.create(title="Next up", close_at=now() + datetime.timedelta(days=1))
-    future_hearing_2 = Hearing.objects.create(title="Next up", close_at=now() + datetime.timedelta(days=5))
-    response = api_client.get(list_endpoint, {"next_closing": now().isoformat()})
-    data = get_data_from_response(response)
-    assert len(data["results"]) == 1
-    assert data["results"][0]["title"][default_lang_code] == future_hearing_1.title
-    response = api_client.get(list_endpoint, {"next_closing": future_hearing_1.close_at.isoformat()})
-    data = get_data_from_response(response)
-    assert len(data["results"]) == 1
-    assert data["results"][0]["title"][default_lang_code] == future_hearing_2.title
-    response = api_client.get(list_endpoint, {"open": "true"})
-    data = get_data_from_response(response)
-    assert len(data["results"]) == 2
-    assert data["results"][0]["title"][default_lang_code].startswith("Next")
-    assert data["results"][1]["title"][default_lang_code].startswith("Next")
-    response = api_client.get(list_endpoint, {"open": "false"})
-    data = get_data_from_response(response)
-    assert len(data["results"]) == 2
-    assert data["results"][0]["title"][default_lang_code].startswith("Gone")
-    assert data["results"][1]["title"][default_lang_code].startswith("Gone")
-
-
-@pytest.mark.django_db
 def test_8_get_detail_check_properties(api_client, default_hearing):
     response = api_client.get(get_hearing_detail_url(default_hearing.id))
 

--- a/democracy/tests/integrationtest/test_hearing.py
+++ b/democracy/tests/integrationtest/test_hearing.py
@@ -27,7 +27,6 @@ from democracy.tests.utils import (
     assert_datetime_fuzzy_equal,
     file_to_bytesio,
     get_data_from_response,
-    get_file_path,
     get_hearing_detail_url,
     get_nested,
     sectionfile_base64_test_data,

--- a/democracy/tests/unittest/test_hearing_filter_set.py
+++ b/democracy/tests/unittest/test_hearing_filter_set.py
@@ -1,0 +1,127 @@
+import datetime
+import pytest
+from django.utils.timezone import now
+from freezegun import freeze_time
+
+from democracy.factories.hearing import MinimalHearingFactory
+from democracy.factories.organization import OrganizationFactory
+from democracy.factories.user import UserFactory
+from democracy.models import Hearing
+from democracy.tests.utils import instance_ids
+from democracy.views.hearing import HearingFilterSet
+
+endpoint = "/v1/hearing/"
+
+
+@pytest.mark.django_db
+def test_filter_created_by_without_user_should_return_unmodified_queryset(rf):
+    organization = OrganizationFactory.create()
+    another_organization = OrganizationFactory.create()
+    MinimalHearingFactory.create_batch(5, organization=another_organization)
+    request = rf.get(endpoint)
+    request.user = None
+
+    hearing_filter_set = HearingFilterSet(
+        queryset=Hearing.objects.all(), data={"created_by": organization.name}, request=request
+    )
+
+    assert hearing_filter_set.qs.count() == 5
+
+
+@pytest.mark.django_db
+def test_filter_created_by_with_me_should_return_hearings_created_by_user(rf):
+    user = UserFactory.create()
+    expected_hearing = MinimalHearingFactory(created_by=user)
+    MinimalHearingFactory(created_by=UserFactory.create())
+    request = rf.get(endpoint)
+    request.user = user
+
+    hearing_filter_set = HearingFilterSet(queryset=Hearing.objects.all(), data={"created_by": "me"}, request=request)
+
+    assert hearing_filter_set.qs.count() == 1
+    assert hearing_filter_set.qs.first() == expected_hearing
+
+
+@pytest.mark.django_db
+def test_filter_created_by_with_organization_name_should_return_hearings_created_by_organization(rf):
+    organization = OrganizationFactory.create()
+    expected_hearing = MinimalHearingFactory(organization=organization)
+    MinimalHearingFactory(organization=OrganizationFactory.create())
+    request = rf.get(endpoint)
+    request.user = UserFactory.create()
+
+    hearing_filter_set = HearingFilterSet(
+        queryset=Hearing.objects.all(), data={"created_by": organization.name}, request=request
+    )
+
+    assert hearing_filter_set.qs.count() == 1
+    assert hearing_filter_set.qs.first() == expected_hearing
+
+
+@pytest.mark.django_db
+def test_filter_created_by_with_non_existing_organization_should_return_unmodified_queryset(rf):
+    MinimalHearingFactory.create_batch(5, organization=OrganizationFactory.create())
+    request = rf.get(endpoint)
+    request.user = UserFactory.create()
+
+    hearing_filter_set = HearingFilterSet(
+        queryset=Hearing.objects.all(), data={"created_by": "non_existing"}, request=request
+    )
+
+    assert hearing_filter_set.qs.count() == 5
+
+
+@freeze_time("2000-01-01T00:00:00Z")
+@pytest.mark.django_db
+def test_filter_open_with_true():
+    next_day = now() + datetime.timedelta(days=1)
+    previous_day = now() - datetime.timedelta(days=1)
+    next_second = now() + datetime.timedelta(seconds=1)
+    previous_second = now() - datetime.timedelta(seconds=1)
+
+    # Hearings that should show up.
+    expected_hearings = [
+        MinimalHearingFactory(open_at=previous_second, close_at=next_second),
+        MinimalHearingFactory(open_at=now(), close_at=next_second),
+        MinimalHearingFactory(open_at=previous_day, close_at=next_day),
+    ]
+
+    # Hearings that should not show up.
+    MinimalHearingFactory(open_at=previous_day, close_at=now())
+    MinimalHearingFactory(open_at=previous_day, close_at=previous_second)
+    MinimalHearingFactory(open_at=next_second, close_at=next_day)
+    MinimalHearingFactory(open_at=previous_day, close_at=next_day, force_closed=True)
+
+    hearing_filter_set = HearingFilterSet(data={"open": True}, queryset=Hearing.objects.all())
+
+    # Should return the expected hearings.
+    assert hearing_filter_set.qs.count() == len(expected_hearings)
+    assert instance_ids(hearing_filter_set.qs) == instance_ids(expected_hearings)
+
+
+@freeze_time("2000-01-01T00:00:00Z")
+@pytest.mark.django_db
+def test_filter_open_with_false():
+    next_day = now() + datetime.timedelta(days=1)
+    previous_day = now() - datetime.timedelta(days=1)
+    next_second = now() + datetime.timedelta(seconds=1)
+    previous_second = now() - datetime.timedelta(seconds=1)
+
+    # Hearings that should show up.
+    expected_hearings = [
+        MinimalHearingFactory(open_at=previous_day, close_at=now()),
+        MinimalHearingFactory(open_at=previous_day, close_at=previous_second),
+        MinimalHearingFactory(open_at=next_second, close_at=next_day),
+        MinimalHearingFactory(open_at=previous_day, close_at=next_day, force_closed=True),
+    ]
+
+    # Hearings that should not show up.
+    MinimalHearingFactory(open_at=previous_second, close_at=next_second)
+    MinimalHearingFactory(open_at=now(), close_at=next_second)
+    MinimalHearingFactory(open_at=previous_day, close_at=next_day)
+
+    hearing_filter_set = HearingFilterSet(data={"open": False}, queryset=Hearing.objects.all())
+
+    # Should return the expected hearings.
+    assert hearing_filter_set.qs.count() == len(expected_hearings)
+    assert instance_ids(hearing_filter_set.qs) == instance_ids(expected_hearings)

--- a/democracy/tests/utils.py
+++ b/democracy/tests/utils.py
@@ -210,3 +210,8 @@ def get_nested(data: Mapping, keys: Iterable):
     for key in keys:
         val = val[key]
     return val
+
+
+def instance_ids(instances: Iterable) -> set:
+    """Get a set of unique IDs from an iterable of model instances, e.g. a list, queryset."""
+    return {instance.id for instance in instances}

--- a/democracy/views/hearing.py
+++ b/democracy/views/hearing.py
@@ -65,12 +65,12 @@ class HearingFilterSet(django_filters.rest_framework.FilterSet):
         if value:
             return (
                 queryset.filter(close_at__gt=datetime.datetime.now())
-                .filter(open_at__lt=datetime.datetime.now())
+                .filter(open_at__lte=datetime.datetime.now())
                 .filter(force_closed=False)
             )
         else:
             return (
-                queryset.filter(close_at__lt=datetime.datetime.now())
+                queryset.filter(close_at__lte=datetime.datetime.now())
                 | queryset.filter(open_at__gt=datetime.datetime.now())
                 | queryset.filter(force_closed=True)
             ).distinct()

--- a/democracy/views/hearing.py
+++ b/democracy/views/hearing.py
@@ -2,7 +2,7 @@ import django_filters
 from collections import defaultdict
 from django.conf import settings
 from django.db import transaction
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Q
 from django.utils import timezone
 from rest_framework import filters, permissions, response, serializers, status, viewsets
 from rest_framework.decorators import action
@@ -68,11 +68,9 @@ class HearingFilterSet(django_filters.rest_framework.FilterSet):
                 .filter(force_closed=False)
             )
         else:
-            return (
-                queryset.filter(close_at__lte=timezone.now())
-                | queryset.filter(open_at__gt=timezone.now())
-                | queryset.filter(force_closed=True)
-            ).distinct()
+            return queryset.filter(
+                Q(close_at__lte=timezone.now()) | Q(open_at__gt=timezone.now()) | Q(force_closed=True)
+            )
 
     def filter_created_by(self, queryset, name, value):
         if not self.request.user:

--- a/democracy/views/hearing.py
+++ b/democracy/views/hearing.py
@@ -1,4 +1,3 @@
-import datetime
 import django_filters
 from collections import defaultdict
 from django.conf import settings
@@ -64,14 +63,14 @@ class HearingFilterSet(django_filters.rest_framework.FilterSet):
     def filter_open(self, queryset, name, value):
         if value:
             return (
-                queryset.filter(close_at__gt=datetime.datetime.now())
-                .filter(open_at__lte=datetime.datetime.now())
+                queryset.filter(close_at__gt=timezone.now())
+                .filter(open_at__lte=timezone.now())
                 .filter(force_closed=False)
             )
         else:
             return (
-                queryset.filter(close_at__lte=datetime.datetime.now())
-                | queryset.filter(open_at__gt=datetime.datetime.now())
+                queryset.filter(close_at__lte=timezone.now())
+                | queryset.filter(open_at__gt=timezone.now())
                 | queryset.filter(force_closed=True)
             ).distinct()
 

--- a/democracy/views/hearing.py
+++ b/democracy/views/hearing.py
@@ -459,7 +459,6 @@ class HearingViewSet(AdminsSeeUnpublishedMixin, viewsets.ModelViewSet):
         return HearingSerializer
 
     def filter_queryset(self, queryset):
-        next_closing = self.request.query_params.get("next_closing", None)
         open = self.request.query_params.get("open", None)
         created_by = self.request.query_params.get("created_by", None)
 
@@ -475,9 +474,6 @@ class HearingViewSet(AdminsSeeUnpublishedMixin, viewsets.ModelViewSet):
                 if organizationObject is not None:
                     queryset = queryset.filter(organization=organizationObject.id)
 
-        if next_closing is not None:
-            # sliced querysets cannot be filtered or ordered further
-            return queryset.filter(close_at__gt=next_closing).order_by("close_at")[:1]
         if open is not None:
             if open.lower() == "false" or open == 0:
                 queryset = (

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -7,6 +7,7 @@ distro
 django-debug-toolbar
 factory-boy
 flake8
+freezegun
 jose
 isort
 pip-tools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -56,6 +56,8 @@ faker==25.2.0
     # via factory-boy
 flake8==7.0.0
     # via -r requirements-dev.in
+freezegun==1.5.1
+    # via -r requirements-dev.in
 idna==3.7
     # via
     #   -c requirements.txt
@@ -108,7 +110,9 @@ pytest-cov==5.0.0
 pytest-django==4.8.0
     # via -r requirements-dev.in
 python-dateutil==2.9.0.post0
-    # via faker
+    # via
+    #   faker
+    #   freezegun
 requests==2.32.2
     # via
     #   -c requirements.txt


### PR DESCRIPTION
Move the `HearingViewSet` filters in `filter_queryset` under `HearingFilterSet` instead and remove the `filter_queryset` override. Also removes an unused (= no requests using this parameter in the past 90 days *and* no references to it in kerrokantasi-ui) `next_closing` filter which had a questionable implementation (returning a sliced queryset in the middle of `filter_queryset` and skipping the rest of the filters isn't exactly expected `filter_queryset` behaviour).

If needed, can be replaced in the future by implementing a `close_at_gt` filter and using it with a `limit=1` query parameter, e.g. `/v1/hearing/?close_at_gt=YYYY-MM-DD&limit=1`.