### PR TITLE
refactor: drop AbstractSerializerMixin IOErrorIgnoringManyRelatedField

### DIFF
--- a/democracy/views/base.py
+++ b/democracy/views/base.py
@@ -6,7 +6,6 @@ from rest_framework import serializers
 from democracy.models.base import BaseModel
 from democracy.models.files import BaseFile
 from democracy.models.images import BaseImage
-from democracy.views.utils import AbstractSerializerMixin
 
 
 class UserFieldSerializer(serializers.ModelSerializer):
@@ -26,7 +25,7 @@ class CreatedBySerializer(serializers.ModelSerializer):
     created_by = UserFieldSerializer()
 
 
-class BaseImageSerializer(AbstractSerializerMixin, serializers.ModelSerializer):
+class BaseImageSerializer(serializers.ModelSerializer):
     """
     Serializer for Image objects.
     """
@@ -53,7 +52,7 @@ class BaseImageSerializer(AbstractSerializerMixin, serializers.ModelSerializer):
         return self.context.get("request")
 
 
-class BaseFileSerializer(AbstractSerializerMixin, serializers.ModelSerializer):
+class BaseFileSerializer(serializers.ModelSerializer):
     """
     Serializer for File objects.
     """

--- a/democracy/views/comment.py
+++ b/democracy/views/comment.py
@@ -14,7 +14,7 @@ from audit_log.views import AuditLogApiView
 from democracy.models.comment import BaseComment
 from democracy.renderers import GeoJSONRenderer
 from democracy.views.base import AdminsSeeUnpublishedMixin, CreatedBySerializer
-from democracy.views.utils import AbstractSerializerMixin, GeoJSONField
+from democracy.views.utils import GeoJSONField
 
 COMMENT_FIELDS = [
     "id",
@@ -34,7 +34,7 @@ COMMENT_FIELDS = [
 ]
 
 
-class BaseCommentSerializer(AbstractSerializerMixin, CreatedBySerializer, serializers.ModelSerializer):
+class BaseCommentSerializer(CreatedBySerializer, serializers.ModelSerializer):
     author_name = serializers.SerializerMethodField()
     is_registered = serializers.SerializerMethodField()
     organization = serializers.SerializerMethodField()


### PR DESCRIPTION
First part of the performance overhaul. I propose dropping some old code that complicates the second part of the performance overhaul a lot. Here's the description of my best attempt at understanding what `IOErrorIgnoringManyRelatedField` was made for:


IOErrorIgnoringManyRelatedField used iterator (cursor), which removes the ability to do prefetches for images and files.

Whatever the original reason was for introducing these, appears to be no longer there at least in the eyes of the commit author. IOErrorIgnoringManyRelatedField was introduced to work around images that were

1) deleted from storage but not from the DB
AND
2) lacking width and height information in the model instance.

In this kind of situation, django attempts to read the image file on constructing a new instance to determine its width and height but would fail with IOError.

Currently, all images in the DB have width and height set, so this error cannot occur as django will not attempt determine the dimensions.

I suspect there was a problem with broken test data in early 2016 which prompted this workaround. The developers were setting up a new test environment in the days prior when the workaround was made. The first images in production are from late 2016.

