### PR TITLE
KER-399 | Command for removing old users

### DIFF
--- a/democracy/factories/comment.py
+++ b/democracy/factories/comment.py
@@ -1,5 +1,4 @@
 import random
-from datetime import timedelta
 
 import factory
 import factory.fuzzy
@@ -12,14 +11,10 @@ class BaseCommentFactory(factory.django.DjangoModelFactory):
     content = factory.Faker("text")
 
     @factory.post_generation
-    def post(self, create, extracted, **kwargs):
+    def create_random_voters(self, create, create_random_voters, **kwargs):
+        if not create_random_voters:
+            return
+
         for _x in range(int(random.random() * random.random() * 5)):
             self.voters.add(get_random_user())
         self.recache_n_votes()
-
-        # Can't be done in a lazy attribute because they have no access to the concrete factory's model class,  # noqa: E501
-        # for `parent_field`...
-        self.created_at = getattr(self, self.parent_field).created_at + timedelta(
-            seconds=random.randint(120, 600)
-        )
-        self.save(update_fields=("created_at",))

--- a/democracy/factories/hearing.py
+++ b/democracy/factories/hearing.py
@@ -84,9 +84,13 @@ class SectionFactory(factory.django.DjangoModelFactory):
         choices=SectionType.objects.exclude(identifier="main")
     )
     commenting = factory.fuzzy.FuzzyChoice(choices=Commenting)
+    hearing = factory.SubFactory(HearingFactory)
 
     @factory.post_generation
-    def post(self, create, extracted, **kwargs):
+    def create_random_comments(self, create, create_random_comments, **kwargs):
+        """By default, create random comments for the section."""
+        if not create_random_comments:
+            return
         for _x in range(random.randint(1, 5)):
             comment = SectionCommentFactory(section=self)
             logger.info(

--- a/democracy/management/commands/remove_user_data.py
+++ b/democracy/management/commands/remove_user_data.py
@@ -1,0 +1,53 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.utils import timezone
+
+from democracy.utils import user_data_remover
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--remove-user-data-from-old-objects",
+            action="store_true",
+            help="Remove user reference from old objects.",
+        )
+        parser.add_argument(
+            "--delete-comment-version-history",
+            action="store_true",
+            help="Delete old comments version history.",
+        )
+        parser.add_argument(
+            "--delete-users",
+            action="store_true",
+            help="Delete users without activity created before threshold.",
+        )
+        parser.add_argument(
+            "--older-than-days",
+            default=settings.DEFAULT_USER_DATA_REMOVAL_THRESHOLD_DAYS,
+            type=int,
+            help=f"Specify the number of days for removal; "
+            f"defaults to {settings.DEFAULT_USER_DATA_REMOVAL_THRESHOLD_DAYS}."
+            f"Data as old or older than this will be removed.",
+        )
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        threshold_time = timezone.now() - timezone.timedelta(
+            days=options["older_than_days"]
+        )
+
+        if options["remove_user_data_from_old_objects"]:
+            user_data_remover.remove_old_objects_user_data(threshold_time)
+            user_data_remover.remove_user_from_old_comments(threshold_time)
+            user_data_remover.remove_user_votes_from_old_comments(threshold_time)
+            user_data_remover.remove_user_from_old_poll_answers(threshold_time)
+            user_data_remover.remove_user_from_old_hearings(threshold_time)
+            user_data_remover.remove_contact_persons_from_old_hearings(threshold_time)
+
+            if options["delete_comment_version_history"]:
+                user_data_remover.delete_old_comments_versions(threshold_time)
+
+        if options["delete_users"]:
+            user_data_remover.delete_old_users_without_activity(threshold_time)

--- a/democracy/tests/integrationtest/test_remove_user_data_command.py
+++ b/democracy/tests/integrationtest/test_remove_user_data_command.py
@@ -1,0 +1,216 @@
+import freezegun
+import pytest
+import reversion
+from django.conf import settings
+from django.core.management import call_command
+from django.utils import timezone
+from reversion.models import Version
+
+from democracy.factories.hearing import (
+    MinimalHearingFactory,
+    SectionCommentFactory,
+    SectionFactory,
+)
+from democracy.factories.poll import SectionPollFactory, SectionPollOptionFactory
+from democracy.models import ContactPerson, SectionComment, SectionPollAnswer
+from kerrokantasi.models import User
+from kerrokantasi.tests.factories import UserFactory
+
+
+def run_remove_user_data_command(*args):
+    call_command("remove_user_data", *args)
+
+
+@pytest.mark.django_db
+class TestRemoveUserDataCommand:
+    @pytest.fixture(autouse=True)
+    def init_test_data(self):
+        with freezegun.freeze_time(
+            timezone.now()
+            - timezone.timedelta(
+                days=settings.DEFAULT_USER_DATA_REMOVAL_THRESHOLD_DAYS + 1
+            )
+        ):
+            sec = SectionFactory(create_random_comments=False)
+            self.old_user = UserFactory(username="old_user", date_joined=timezone.now())
+            self.old_user_without_activity = UserFactory(
+                username="tobe_deleted_user", date_joined=timezone.now()
+            )
+            with reversion.create_revision():
+                self.old_section_comment = SectionCommentFactory(
+                    created_by=self.old_user, section=sec, create_random_voters=False
+                )
+                self.old_section_comment.title = "Old Title"
+                self.old_section_comment.save()
+            self.old_section_comment.voters.add(self.old_user)
+            self.old_section_comment.recache_n_votes()
+            self.old_hearing = MinimalHearingFactory(created_by=self.old_user)
+            SectionComment.objects.filter(section__hearing=self.old_hearing).delete()
+            self.old_contact_person = ContactPerson.objects.create(
+                name="Old Contact Person", created_by=self.old_user
+            )
+            self.old_hearing.contact_persons.add(self.old_contact_person)
+            poll = SectionPollFactory(section=sec)
+            option = SectionPollOptionFactory(poll=poll)
+            self.old_poll_answer = SectionPollAnswer.objects.create(
+                created_by=self.old_user,
+                option=option,
+                comment=self.old_section_comment,
+            )
+
+        self.new_user = UserFactory(username="newer_user", date_joined=timezone.now())
+        self.new_section_comment = SectionCommentFactory(
+            created_by=self.new_user, section=sec, create_random_voters=False
+        )
+        self.new_hearing = MinimalHearingFactory(
+            created_by=self.new_user, close_at=timezone.now()
+        )
+        self.new_contact_person = ContactPerson.objects.create(
+            name="New Contact Person", created_by=self.new_user
+        )
+        self.new_hearing.contact_persons.add(self.new_contact_person)
+        self.new_poll_answer = SectionPollAnswer.objects.create(
+            created_by=self.new_user, option=option, comment=self.new_section_comment
+        )
+
+    old_objects = [
+        "old_section_comment",
+        "old_poll_answer",
+        "old_hearing",
+    ]
+    new_objects = [
+        "new_section_comment",
+        "new_hearing",
+        "new_contact_person",
+        "new_poll_answer",
+    ]
+
+    def test_delete_user(self):
+        self.old_user.delete()
+        self.old_section_comment.refresh_from_db()
+        self.old_hearing.refresh_from_db()
+        self.old_poll_answer.refresh_from_db()
+        self.old_contact_person.refresh_from_db()
+        assert self.old_section_comment.created_by is None
+        assert self.old_hearing.created_by is None
+        assert self.old_poll_answer.created_by is None
+        assert self.old_contact_person.created_by is None
+        assert self.old_section_comment.content is not None
+        assert self.old_section_comment.content != ""
+        assert self.old_section_comment.id > 0
+
+    def assert_old_objects_created_by_matches(self, exclude=()):
+        for model in [model for model in self.old_objects if model not in exclude]:
+            obj = getattr(self, model)
+            obj.refresh_from_db()
+            assert obj.created_by == self.old_user
+
+    def assert_old_objects_created_by_none(self, exclude=()):
+        for model in [model for model in self.old_objects if model not in exclude]:
+            obj = getattr(self, model)
+            obj.refresh_from_db()
+            assert obj.created_by is None
+
+    def assert_new_objects_created_by_matches(self):
+        for model in self.new_objects:
+            obj = getattr(self, model)
+            obj.refresh_from_db()
+            assert obj.created_by == self.new_user
+
+    def test_all_options(self):
+        """Test remove_user_data command with all options."""
+        args = [
+            "--remove-user-data-from-old-objects",
+            "--delete-comment-version-history",
+            "--delete-users",
+            "--older-than-days",
+            str(settings.DEFAULT_USER_DATA_REMOVAL_THRESHOLD_DAYS),
+        ]
+        run_remove_user_data_command(*args)
+
+        self.old_section_comment.refresh_from_db()
+        self.old_poll_answer.refresh_from_db()
+        self.old_hearing.refresh_from_db()
+        old_user = User.objects.filter(id=self.old_user.id).first()
+        user_without_activity = User.objects.filter(
+            username=self.old_user_without_activity.username
+        ).first()
+        self.new_user.refresh_from_db()
+
+        self.assert_old_objects_created_by_none()
+        assert self.old_hearing.contact_persons.count() == 0
+        assert self.old_section_comment.n_unregistered_votes == 1
+        assert self.old_section_comment.voters.count() == 0
+        assert self.old_section_comment.n_votes == 1
+        self.assert_new_objects_created_by_matches()
+        assert Version.objects.get_for_object(self.old_section_comment).count() == 0
+
+        assert user_without_activity is None
+        assert old_user is None
+        assert self.new_user is not None
+
+    def test_remove_only_user_data_from_old_objects(self):
+        """Test remove_user_data command with remove_user_data_from_old_objects option."""
+        args = ["--remove-user-data-from-old-objects"]
+        run_remove_user_data_command(*args)
+
+        self.old_section_comment.refresh_from_db()
+        self.old_poll_answer.refresh_from_db()
+        self.old_hearing.refresh_from_db()
+
+        self.assert_old_objects_created_by_none()
+        assert self.old_section_comment.n_unregistered_votes == 1
+        assert self.old_section_comment.voters.count() == 0
+        assert self.old_section_comment.n_votes == 1
+        assert self.old_hearing.contact_persons.count() == 0
+
+        self.assert_new_objects_created_by_matches()
+
+    def test_remove_user_data_from_old_objects_with_delete_version_option(self):
+        """Test remove_user_data command with remove_user_data_from_old_objects option."""
+        args = [
+            "--remove-user-data-from-old-objects",
+            "--delete-comment-version-history",
+        ]
+
+        assert Version.objects.get_for_object(self.old_section_comment).count() > 0
+        run_remove_user_data_command(*args)
+
+        self.old_section_comment.refresh_from_db()
+        self.old_poll_answer.refresh_from_db()
+        self.old_hearing.refresh_from_db()
+
+        self.assert_old_objects_created_by_none()
+        assert self.old_section_comment.n_unregistered_votes == 1
+        assert self.old_section_comment.voters.count() == 0
+        assert self.old_section_comment.n_votes == 1
+        assert self.old_hearing.contact_persons.count() == 0
+
+        self.assert_new_objects_created_by_matches()
+
+        assert Version.objects.get_for_object(self.old_section_comment).count() == 0
+
+    def test_only_delete_inactive_users(self):
+        """Test remove_user_data command with delete_users option."""
+        args = ["--delete-users"]
+        run_remove_user_data_command(*args)
+
+        self.old_section_comment.refresh_from_db()
+        self.old_poll_answer.refresh_from_db()
+        self.old_hearing.refresh_from_db()
+
+        self.assert_old_objects_created_by_matches()
+        assert self.old_section_comment.n_unregistered_votes == 0
+        assert self.old_section_comment.voters.count() == 1
+        assert self.old_section_comment.n_votes == 1
+        assert self.old_hearing.contact_persons.count() == 1
+
+        self.assert_new_objects_created_by_matches()
+        old_user = User.objects.filter(id=self.old_user.id).first()
+        user_without_activity = User.objects.filter(
+            username=self.old_user_without_activity.username
+        ).first()
+        self.new_user.refresh_from_db()
+        assert user_without_activity is None
+        assert old_user is not None
+        assert self.new_user is not None

--- a/democracy/tests/unittest/test_user_data_remover.py
+++ b/democracy/tests/unittest/test_user_data_remover.py
@@ -1,0 +1,369 @@
+import freezegun
+import pytest
+import reversion
+from django.utils import timezone
+from reversion.models import Version
+
+from democracy.factories.hearing import (
+    CommentImageFactory,
+    HearingFactory,
+    LabelFactory,
+    MinimalHearingFactory,
+    SectionCommentFactory,
+    SectionFactory,
+    SectionFileFactory,
+    SectionImageFactory,
+)
+from democracy.factories.organization import OrganizationFactory
+from democracy.factories.poll import SectionPollFactory, SectionPollOptionFactory
+from democracy.models import (
+    ContactPerson,
+    Project,
+    ProjectPhase,
+    SectionPollAnswer,
+    SectionType,
+)
+from democracy.utils import user_data_remover
+from kerrokantasi.models import User
+from kerrokantasi.tests.factories import UserFactory
+
+
+@pytest.fixture
+def user():
+    return UserFactory()
+
+
+@pytest.fixture
+def threshold_time():
+    return timezone.now() - timezone.timedelta(days=30)
+
+
+@pytest.mark.django_db
+class TestRemoveUserFromComments:
+    def test_user_data_nulled_after_threshold_time(self, user, threshold_time):
+        with freezegun.freeze_time(threshold_time - timezone.timedelta(days=1)):
+            comment = SectionCommentFactory(
+                created_by=user, section=SectionFactory(), flagged_by=user
+            )
+        dont_remove_user_from_comment = SectionCommentFactory(
+            created_by=user, section=SectionFactory()
+        )
+
+        user_data_remover.remove_user_from_old_comments(threshold_time)
+        comment.refresh_from_db()
+        dont_remove_user_from_comment.refresh_from_db()
+        assert comment.created_by is None
+        assert comment.modified_by is None
+        assert comment.deleted_by is None
+        assert comment.author_name is None
+        assert comment.flagged_by is None
+        assert dont_remove_user_from_comment.created_by == user
+
+    def test_delete_versions_from_old_comments(self, user, threshold_time):
+        with (
+            freezegun.freeze_time(threshold_time - timezone.timedelta(days=1)),
+            reversion.create_revision(),
+        ):
+            comment = SectionCommentFactory(created_by=user, section=SectionFactory())
+        with reversion.create_revision():
+            comment_too = SectionCommentFactory(
+                created_by=user, section=SectionFactory()
+            )
+            comment.title = "new version"
+            comment_too.title = "new version too"
+            comment.save()
+            comment_too.save()
+
+        assert Version.objects.get_for_object(comment).count() > 0
+        user_data_remover.delete_old_comments_versions(threshold_time)
+        assert Version.objects.get_for_object(comment).count() == 0
+        assert Version.objects.get_for_object(comment_too).count() > 0
+
+    def test_voter_removal_moves_voters_vote_to_unregistered_votes(
+        self, user, threshold_time
+    ):
+        with freezegun.freeze_time(threshold_time - timezone.timedelta(days=1)):
+            comment = SectionCommentFactory(created_by=user, section=SectionFactory())
+        user = User.objects.create(username="voter")
+        UserFactory(username="not_voter")
+        comment.voters.add(user)
+        comment.recache_n_votes()
+        vote_count = comment.n_votes
+
+        assert vote_count == comment.voters.count()
+        assert comment.n_unregistered_votes == 0
+
+        user_data_remover.remove_user_votes_from_old_comments(threshold_time)
+        comment.refresh_from_db()
+        assert comment.voters.count() == 0
+        assert vote_count == comment.n_unregistered_votes
+        assert vote_count == comment.n_votes
+
+    def test_user_removed_from_poll_answers_after_threshold_time(
+        self, user, threshold_time
+    ):
+        with freezegun.freeze_time(threshold_time - timezone.timedelta(days=1)):
+            poll_answer = SectionPollAnswer.objects.create(
+                option=SectionPollOptionFactory(),
+                comment=SectionCommentFactory(section=SectionFactory()),
+                created_by=user,
+            )
+        dont_remove_user_poll_answer = SectionPollAnswer.objects.create(
+            option=SectionPollOptionFactory(),
+            comment=SectionCommentFactory(section=SectionFactory()),
+            created_by=user,
+            modified_by=user,
+            deleted_by=user,
+        )
+        user_data_remover.remove_user_from_old_poll_answers(threshold_time)
+
+        poll_answer.refresh_from_db()
+        dont_remove_user_poll_answer.refresh_from_db()
+
+        assert user == dont_remove_user_poll_answer.created_by
+        assert poll_answer.created_by is None
+        assert poll_answer.modified_by is None
+        assert poll_answer.deleted_by is None
+
+
+@pytest.mark.django_db
+class TestRemoveUserFromHearing:
+    def test_hearing_user_fields_are_nulled_after_threshold(self, user, threshold_time):
+        with freezegun.freeze_time(threshold_time - timezone.timedelta(days=1)):
+            hearing = HearingFactory(
+                close_at=timezone.now(),
+                created_by=user,
+                modified_by=user,
+                deleted_by=user,
+            )
+
+        dont_remove_user_from_hearing = HearingFactory(
+            close_at=timezone.now(),
+            created_by=user,
+            modified_by=user,
+            deleted_by=user,
+        )
+
+        user_data_remover.remove_user_from_old_hearings(threshold_time)
+        hearing.refresh_from_db()
+        dont_remove_user_from_hearing.refresh_from_db()
+
+        assert hearing.created_by is None
+        assert hearing.modified_by is None
+        assert hearing.deleted_by is None
+        assert dont_remove_user_from_hearing.created_by is not None
+        assert dont_remove_user_from_hearing.modified_by is not None
+        assert dont_remove_user_from_hearing.deleted_by is not None
+
+    def test_hearing_contact_persons_are_cleared_after_threshold_time(
+        self, user, threshold_time
+    ):
+        with freezegun.freeze_time(threshold_time - timezone.timedelta(days=1)):
+            hearing = HearingFactory(
+                close_at=timezone.now(),
+                created_by=user,
+                modified_by=user,
+                deleted_by=user,
+            )
+            hearing.contact_persons.add(
+                ContactPerson.objects.create(
+                    name="contact",
+                )
+            )
+        assert hearing.contact_persons.count() == 1
+
+        dont_remove_user_hearing = HearingFactory(
+            close_at=timezone.now(),
+            created_by=user,
+            modified_by=user,
+            deleted_by=user,
+        )
+        dont_remove_user_hearing.contact_persons.add(
+            ContactPerson.objects.create(
+                name="contact",
+            )
+        )
+
+        user_data_remover.remove_contact_persons_from_old_hearings(threshold_time)
+        hearing.refresh_from_db()
+        dont_remove_user_hearing.refresh_from_db()
+
+        assert hearing.contact_persons.count() == 0
+        assert dont_remove_user_hearing.contact_persons.count() == 1
+
+    def test_contact_person_deleted_if_not_used_threshold_time(
+        self, user, threshold_time
+    ):
+        contact_person = ContactPerson.objects.create(
+            name="contact",
+        )
+        with freezegun.freeze_time(threshold_time - timezone.timedelta(days=1)):
+            hearing = HearingFactory(
+                close_at=timezone.now(),
+                created_by=user,
+                modified_by=user,
+                deleted_by=user,
+            )
+            hearing.contact_persons.add(contact_person)
+
+        dont_delete_hearing = HearingFactory(
+            close_at=timezone.now(),
+            created_by=user,
+            modified_by=user,
+            deleted_by=user,
+        )
+        contact_too = ContactPerson.objects.create(name="contact_too")
+        dont_delete_hearing.contact_persons.add(contact_too)
+
+        assert ContactPerson.objects.count() == 2
+
+        user_data_remover.remove_contact_persons_from_old_hearings(threshold_time)
+        contact_too.refresh_from_db()
+
+        assert ContactPerson.objects.count() == 1
+        assert contact_too.id is not None
+
+
+@pytest.mark.django_db
+class TestUserDelete:
+    def test_user_is_deleted_when_no_activity(self, user, threshold_time):
+        with freezegun.freeze_time(threshold_time - timezone.timedelta(days=1)):
+            UserFactory(username="inactive")
+
+        assert User.objects.filter(username="inactive").first() is not None
+        user_data_remover.delete_old_users_without_activity(threshold_time)
+        assert User.objects.filter(username="inactive").first() is None
+
+    def test_old_user_is_not_deleted_if_active_after_threshold(
+        self, user, threshold_time
+    ):
+        with freezegun.freeze_time(threshold_time - timezone.timedelta(days=1)):
+            active_old_user = UserFactory(username="active")
+
+        SectionCommentFactory(created_by=active_old_user, section=SectionFactory())
+
+        user_data_remover.delete_old_users_without_activity(threshold_time)
+
+        assert User.objects.filter(username="active").first() is not None
+
+    def test_old_user_is_deleted_after_its_activity_removed(self, user, threshold_time):
+        with freezegun.freeze_time(threshold_time - timezone.timedelta(days=1)):
+            active_old_user = UserFactory(username="inactive")
+            SectionCommentFactory(
+                created_by=active_old_user,
+                section=SectionFactory(created_by=active_old_user),
+            )
+            MinimalHearingFactory(created_by=active_old_user, close_at=timezone.now())
+
+        user_data_remover.remove_user_from_old_comments(threshold_time)
+        user_data_remover.remove_old_objects_user_data(threshold_time)
+        user_data_remover.remove_user_from_old_hearings(threshold_time)
+        user_data_remover.remove_user_votes_from_old_comments(threshold_time)
+        user_data_remover.delete_old_users_without_activity(threshold_time)
+
+        assert User.objects.filter(username="inactive").first() is None
+
+    def test_user_is_not_deleted_if_joined_after_threshold(self, user, threshold_time):
+        user_data_remover.delete_old_users_without_activity(threshold_time)
+        assert User.objects.filter(id=user.id).first() is not None
+
+
+@pytest.mark.django_db
+class TestRemoveUserDataFromModels:
+    @pytest.fixture(autouse=True)
+    def create_data_in_time(self, threshold_time, user):
+        create_time = threshold_time - timezone.timedelta(days=1)
+        with freezegun.freeze_time(create_time):
+            ContactPerson.objects.create(
+                created_by=user,
+                modified_by=user,
+                deleted_by=user,
+            )
+            hearing = MinimalHearingFactory()
+            section = SectionFactory(
+                hearing=hearing,
+                create_random_comments=False,
+                created_by=user,
+                modified_by=user,
+                deleted_by=user,
+            )
+            poll = SectionPollFactory(
+                created_by=user,
+                modified_by=user,
+                deleted_by=user,
+                section=section,
+            )
+            SectionPollAnswer.objects.create(
+                option=SectionPollOptionFactory(poll=poll),
+                comment=SectionCommentFactory(
+                    created_by=user,
+                    modified_by=user,
+                    deleted_by=user,
+                    section=SectionFactory(),
+                ),
+                created_by=user,
+                modified_by=user,
+                deleted_by=user,
+            )
+            project = Project.objects.create(
+                created_by=user,
+                modified_by=user,
+                deleted_by=user,
+            )
+            ProjectPhase.objects.create(
+                created_by=user,
+                modified_by=user,
+                deleted_by=user,
+                project=project,
+            )
+            OrganizationFactory(
+                created_by=user,
+                modified_by=user,
+                deleted_by=user,
+            )
+            LabelFactory(
+                created_by=user,
+                modified_by=user,
+                deleted_by=user,
+            )
+            SectionType.objects.create(
+                created_by=user,
+                modified_by=user,
+                deleted_by=user,
+            )
+            SectionImageFactory(
+                created_by=user,
+                modified_by=user,
+                deleted_by=user,
+                section=section,
+            )
+            SectionFileFactory(created_by=user, modified_by=user, deleted_by=user)
+            SectionPollOptionFactory(
+                created_by=user,
+                modified_by=user,
+                deleted_by=user,
+                poll=poll,
+            )
+            CommentImageFactory(
+                comment=SectionCommentFactory(section=section),
+                created_by=user,
+                modified_by=user,
+                deleted_by=user,
+            )
+
+    def test_user_details_are_removed_from_listed_models_after_threshold(
+        self, user, threshold_time
+    ):
+        listed_models = user_data_remover.LOOKUP_OBJECTS
+
+        for o in listed_models:
+            assert o.objects.filter(created_by=user).count() == 1
+            assert o.objects.filter(modified_by=user).count() == 1
+            assert o.objects.filter(deleted_by=user).count() == 1
+
+        user_data_remover.remove_old_objects_user_data(threshold_time)
+
+        for o in listed_models:
+            assert o.objects.filter(created_by=user).count() == 0
+            assert o.objects.filter(modified_by=user).count() == 0
+            assert o.objects.filter(deleted_by=user).count() == 0

--- a/democracy/utils/user_data_remover.py
+++ b/democracy/utils/user_data_remover.py
@@ -1,0 +1,207 @@
+from datetime import datetime
+from typing import TypeVar
+
+from django.db.models import QuerySet
+from reversion.models import Version
+
+from democracy.models import (
+    ContactPerson,
+    Hearing,
+    Label,
+    Organization,
+    Project,
+    ProjectPhase,
+    Section,
+    SectionComment,
+    SectionFile,
+    SectionImage,
+    SectionPoll,
+    SectionPollAnswer,
+    SectionPollOption,
+    SectionType,
+)
+from democracy.models.base import BaseModel
+from democracy.models.section import CommentImage
+from kerrokantasi.models import User
+
+B = TypeVar("B", bound=BaseModel)
+
+
+LOOKUP_OBJECTS = [
+    ContactPerson,
+    SectionPollAnswer,
+    Project,
+    ProjectPhase,
+    Organization,
+    Section,
+    Label,
+    SectionType,
+    SectionImage,
+    SectionFile,
+    SectionPoll,
+    SectionPollOption,
+    CommentImage,
+]
+
+# Getting the objects
+
+
+def get_hearings_closed_before(before: datetime) -> QuerySet[Hearing]:
+    """Returns hearings that were closed on or before the given datetime."""
+    return Hearing.objects.filter(close_at__lt=before)
+
+
+def get_objects_before(model: type(B), before: datetime) -> QuerySet[B]:
+    """Returns objects that were created before the given datetime."""
+    return model.objects.filter(created_at__lt=before)
+
+
+def get_inactive_users(
+    joined_before: datetime,
+) -> QuerySet[User]:
+    """Returns all users that have joined before given datetime and are not creators
+    or modifiers of hearings, comments, polls, organizations, files, images, polls
+    or are not listed in any voters.
+    """
+    return User.objects.filter(
+        date_joined__lt=joined_before,
+        sectioncomment_created__isnull=True,
+        sectioncomment_modified__isnull=True,
+        hearing_created__isnull=True,
+        hearing_modified__isnull=True,
+        sectionpollanswer_created__isnull=True,
+        sectionpollanswer_modified__isnull=True,
+        section_created__isnull=True,
+        section_modified__isnull=True,
+        organization_created__isnull=True,
+        organization_modified__isnull=True,
+        project_created__isnull=True,
+        project_modified__isnull=True,
+        projectphase_created__isnull=True,
+        projectphase_modified__isnull=True,
+        contactperson_created__isnull=True,
+        contactperson_modified__isnull=True,
+        label_created__isnull=True,
+        label_modified__isnull=True,
+        sectiontype_created__isnull=True,
+        sectiontype_modified__isnull=True,
+        sectionimage_created__isnull=True,
+        sectionimage_modified__isnull=True,
+        sectionfile_created__isnull=True,
+        sectionfile_modified__isnull=True,
+        sectionpoll_created__isnull=True,
+        sectionpoll_modified__isnull=True,
+        sectionpolloption_created__isnull=True,
+        sectionpolloption_modified__isnull=True,
+        commentimage_created__isnull=True,
+        commentimage_modified__isnull=True,
+        voted_democracy_sectioncomment__isnull=True,
+    )
+
+
+# Manipulating the objects
+
+
+def _delete_versions_from_comments(comments: QuerySet[SectionComment]):
+    """Deletes version history from given set of comments."""
+    for comment in comments:
+        versions = Version.objects.get_for_object(comment)
+        versions.delete()
+
+
+def _remove_users_from_voters(section_comment: SectionComment):
+    """Removes given user from section_comment's voters and add one vote to
+    n_unregistered_votes field.
+    """
+    count = section_comment.voters.count()
+    section_comment.n_unregistered_votes += count
+    section_comment.voters.clear()
+    section_comment.save()
+
+
+def _remove_user_from_poll_answers(comments: QuerySet[SectionComment]):
+    """Remove user from the poll_answers by setting the user referenced
+    fields to None.
+    """
+    polls = SectionPollAnswer.objects.filter(comment__in=comments)
+    _set_base_model_user_fields_to_null(polls)
+
+
+def _set_base_model_user_fields_to_null(model_qs: QuerySet[BaseModel]):
+    """Set the created_by, modified_by and delete_by fields of the given
+    base model queryset to None.
+    """
+    model_qs.update(created_by=None, modified_by=None, deleted_by=None)
+
+
+def delete_old_users_without_activity(joined_before: datetime):
+    """Delete users which have not created or modified hearings, comments, polls,
+    or voted and area joined before the given datetime.
+    """
+    users = get_inactive_users(joined_before)
+    users.delete()
+
+
+def delete_old_comments_versions(before: datetime):
+    """Delete version history from comments that have been created before the
+    given datetime.
+    """
+    comments = get_objects_before(SectionComment, before)
+    _delete_versions_from_comments(comments)
+
+
+def remove_contact_persons_from_old_hearings(before: datetime):
+    """Unlink contact persons from hearings that have been closed before the
+    given datetime. Delete the contact person objects if they are not associated with
+    any hearings or organizations.
+    """
+    hearings = get_hearings_closed_before(before)
+
+    for hearing in hearings:
+        hearing.contact_persons.clear()
+
+    ContactPerson.objects.filter(hearings=None, organization=None).delete()
+
+
+def remove_old_objects_user_data(before: datetime, exclude=()):
+    """Remove user data from old objects that have been created before the
+    given datetime.
+    """
+    for object_class in [o for o in LOOKUP_OBJECTS if o not in exclude]:
+        objects = get_objects_before(object_class, before)
+        _set_base_model_user_fields_to_null(objects)
+
+
+def remove_user_from_old_comments(before: datetime):
+    """Remove user from comment by setting the user referenced fields and author_name
+    to None.
+    """
+    comments = get_objects_before(SectionComment, before)
+    _set_base_model_user_fields_to_null(comments)
+    comments.update(author_name=None, flagged_by=None)
+
+
+def remove_user_from_old_hearings(before: datetime):
+    """Unlink contact persons from hearings that have been close_at since the
+    given datetime.
+    """
+    hearings = get_hearings_closed_before(before)
+
+    _set_base_model_user_fields_to_null(hearings)
+
+
+def remove_user_from_old_poll_answers(before: datetime):
+    """Remove user from old poll answers that have been created before the
+    given datetime.
+    """
+    comments = get_objects_before(SectionComment, before)
+    _remove_user_from_poll_answers(comments)
+
+
+def remove_user_votes_from_old_comments(before: datetime):
+    """Moves user votes to unregistered votes for comments. Removed votes are put
+    to n_unregistered_votes field.
+    """
+    comments = get_objects_before(SectionComment, before)
+    for comment in comments:
+        _remove_users_from_voters(comment)

--- a/kerrokantasi/settings/base.py
+++ b/kerrokantasi/settings/base.py
@@ -92,6 +92,7 @@ env = environ.Env(
     GDPR_API_DELETE_SCOPE=(str, "gdprdelete"),
     # Audit logging
     AUDIT_LOG_ENABLED=(bool, False),
+    DEFAULT_USER_DATA_REMOVAL_THRESHOLD_DAYS=(int, 365 * 5),  # Five years.
 )
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -433,3 +434,7 @@ AUDIT_LOG = {
     "ENABLED": env("AUDIT_LOG_ENABLED"),
     "ORIGIN": "kerrokantasi",
 }
+
+DEFAULT_USER_DATA_REMOVAL_THRESHOLD_DAYS = env(
+    "DEFAULT_USER_DATA_REMOVAL_THRESHOLD_DAYS"
+)


### PR DESCRIPTION
Adds functionality to remove users from objects (*_created, *_modified, *_deleted) and delete inactive users in form of django command.
Command to be added in cron job.

Refs KER-398 KER-399 KER-401