### PR TITLE
chore: whitelist pyproject.toml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,3 +21,4 @@
 !requirements*
 !setup.cfg
 !package.json
+!pyproject.toml


### PR DESCRIPTION
`pyproject.toml` contains configurations for pytest, for example. This needs to be included in the container or else some features might not work as intended.