### PR TITLE
feat: add missing fields in HearingCreateUpdateSerializer

### DIFF
--- a/democracy/tests/conftest.py
+++ b/democracy/tests/conftest.py
@@ -200,7 +200,6 @@ def valid_hearing_json(contact_person, default_label):
         "closed": True,
         "organization": None,
         "geojson": None,
-        "main_image": None,
         "contact_persons": [
             {
                 "id": contact_person.id,


### PR DESCRIPTION
The response from POST requests do not match with GET requests. This PR makes the related serializers a bit more consistent between each other.

Done in a very lazy/MVP way, i.e. a lot of copy-pasting. The serializers need a lot of rework, which I am not going to cover in this, since it would take way too much time.