### PR TITLE
fix(hearing): distinguish absent project field from null in PATCH/PUT

### DIFF
--- a/democracy/tests/integrationtest/test_hearing.py
+++ b/democracy/tests/integrationtest/test_hearing.py
@@ -1690,6 +1690,29 @@ def test_PUT_hearing_with_project_phase_is_active(
     assert_hearing_equals(data, updated_data, john_smith_api_client.user, create=False)
 
 
+# Test that a user can clear the project from a hearing via PUT with project: null
+@pytest.mark.django_db
+def test_PUT_hearing_clears_project(
+    valid_hearing_json_with_project, john_smith_api_client
+):
+    response = john_smith_api_client.post(
+        endpoint, data=valid_hearing_json_with_project, format="json"
+    )
+    data = get_data_from_response(response, status_code=201)
+    assert data["project"] is not None
+    _update_hearing_data(data)
+
+    data["project"] = None
+    response = john_smith_api_client.put(
+        "%s%s/" % (endpoint, data["id"]), data=data, format="json"
+    )
+    updated_data = get_data_from_response(response, status_code=200)
+
+    assert updated_data["project"] is None
+    hearing = Hearing.objects.get(pk=updated_data["id"])
+    assert hearing.project_phase_id is None
+
+
 # Test that a user cannot PUT a hearing without the translation
 @pytest.mark.django_db
 def test_PUT_hearing_untranslated(valid_hearing_json, john_smith_api_client):
@@ -2062,6 +2085,27 @@ def test_PATCH_hearing_with_project_phase_is_active(
     assert data["closed"] is True
     for index, phase in enumerate(phases):
         assert data["project"]["phases"][index]["is_active"] == phase["is_active"]
+
+
+# Test that a user can clear the project from a hearing via PATCH with project: null
+@pytest.mark.django_db
+def test_PATCH_hearing_clears_project(
+    valid_hearing_json_with_project, john_smith_api_client
+):
+    response = john_smith_api_client.post(
+        endpoint, data=valid_hearing_json_with_project, format="json"
+    )
+    data = get_data_from_response(response, status_code=201)
+    assert data["project"] is not None
+
+    response = john_smith_api_client.patch(
+        "%s%s/" % (endpoint, data["id"]), data={"project": None}, format="json"
+    )
+    updated_data = get_data_from_response(response, status_code=200)
+
+    assert updated_data["project"] is None
+    hearing = Hearing.objects.get(pk=updated_data["id"])
+    assert hearing.project_phase_id is None
 
 
 # Test that a user cannot PATCH a hearing without the translation

--- a/democracy/views/hearing.py
+++ b/democracy/views/hearing.py
@@ -15,6 +15,7 @@ from drf_spectacular.utils import (
 from rest_framework import filters, permissions, response, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
+from rest_framework.fields import empty
 from rest_framework.settings import api_settings
 
 from audit_log.utils import add_audit_logged_object_ids
@@ -276,12 +277,16 @@ class HearingCreateUpdateSerializer(
         """
         Create or update project associated to a hearing.
         Handles the following cases:
-            - Project is None
+            - Project is empty (field not sent) -> do nothing
+            - Project is None -> clear project_phase
             - A new project with phases is created
             - An existing project with phases is used
             - An existing project with phases is used, but modified
         """
+        if project_data is empty:
+            return None
         if project_data is None:
+            hearing.project_phase = None
             return None
 
         serializer_params = {
@@ -336,12 +341,14 @@ class HearingCreateUpdateSerializer(
                 "Only organization admins can update organization hearings."
             )
 
+        project_data = validated_data.pop("project", empty)
         if self.partial:
-            return super().update(instance, validated_data)
+            super().update(instance, validated_data)
+            self._create_or_update_project(instance, project_data)
+            return instance
 
         contact_person_data = validated_data.pop("contact_persons", None)
         sections_data = validated_data.pop("sections")
-        project_data = validated_data.pop("project", None)
         validated_data["modified_by_id"] = self.context["request"].user.id
         hearing = super().update(instance, validated_data)
         self._create_or_update_contact_persons(hearing, contact_person_data)


### PR DESCRIPTION
When removing a project from a hearing, the backend failed to clear project_phase because:

1. PATCH requests returned early before processing the project field at all
2. PUT requests with project=null were treated as 'no change' since _create_or_update_project returned None for both absent and null cases

Fix uses DRF's empty sentinel to distinguish between a missing field (don't update) and an explicit null (clear project_phase). For PATCH requests, also checks initial_data to determine if the field was sent.

Refs: KER-563
