### PR TITLE
chore(deps): make django dep lower case

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "kerrokantasi"
 requires-python = ">=3.12, <3.13"
 version = "2.10.6"
 dependencies = [
-    "Django~=5.2.15",
+    "django~=5.2.15",
     "djangorestframework",
     "django-environ",
     "django-extensions",


### PR DESCRIPTION
To fix issues updating django dependency with dependabot make the django lowercase.

Refs: KER-633



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the Django dependency name while retaining the existing version requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->