### PR TITLE
chore: remove patch version from dependency pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "kerrokantasi"
 requires-python = ">=3.12, <3.13"
 version = "2.10.6"
 dependencies = [
-    "django~=5.2.15",
+    "django~=5.2",
     "djangorestframework",
     "django-environ",
     "django-extensions",

--- a/uv.lock
+++ b/uv.lock
@@ -910,7 +910,7 @@ prod = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = "~=5.2.15" },
+    { name = "django", specifier = "~=5.2" },
     { name = "django-autoslug" },
     { name = "django-cors-headers" },
     { name = "django-environ" },


### PR DESCRIPTION
Pin to minor ~5.2

Refs: KER-633



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Broadened the supported Django 5.2 version range, allowing compatible 5.2 updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->